### PR TITLE
Convert option parsing to use commands for the three major choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,96 +21,120 @@ Call it `ssm` and make sure it is executable (`chmod +x ssm`).
 
 ## Usage
 
-Assuming you have followed the above instructions you run the program
-as follows:
+The automatically generated help section for `ssm` is
 
-    ssm <args>
+```
+Usage: ssm [cmd|repl|ssh] [options]
+  -p, --profile <value>    the AWS profile name to use for authenticating this execution
+  -i, --instances <value>  specify the instance ID(s) on which the specified command(s) should execute
+  -t, --tags <value>       search for instances by tag e.g. '--tags app,stack,stage'
+  -r, --region <value>     AWS region name (defaults to eu-west-1)
 
-### Usage examples
+Command: cmd [options]
+execute a single (bash) command, or a file containing bash commands
+  -c, --cmd <value>        a bash command to execute
+  -f, --file <value>       a file containing bash commands to execute
 
-Likely example using short form of arguments (here the command is set to `ls`):
+Command: repl
+run SSM in interactive/repl mode
 
-    ssm -t <app>,<stack>,<stage> --profile <aws-profile> -c ls
+Command: ssh
+```
 
-REPL (interactive) mode:
+The general syntax is 
 
-    ssm -t <app>,<stack>,<stage> --profile <aws-profile> -I
+```
+ssm [cmd|repl|ssh] [options]
+```
 
-Execute a command on all matching instances:
+An example of `cmd` (from the same folder where `ssm.jar` is located) is 
 
-    ssm --ass-tags <app>,<stack>,<stage> --profile <aws-profile> --cmd ls
+```
+java -jar ./ssm.jar cmd -c ls --profile security -t security-hq,security,PROD
+```
 
-Execute the contents of a script file on matching instances:
+... but, as per advised in the **Installation** section, if you have the `ssm` wrapper set up this can be rewritten 
 
-    ssm --ass-tags <app>,<stack>,<stage> --profile <aws-profile> --src-file <script>
+```
+ssm cmd -c ls --profile security -t security-hq,security,PROD
+```
 
-Execute `ls` on the specified instance:
+For more information about `--profile` see [AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
 
-    ssm --instances i-01234567 --profile <aws-profile> --cmd ls
+The general syntax for the `-t` switch is `-t <app>,<stack>,<stage>`. 
 
-Execute `ls` on multiple specified instances (using the short form of
-the arguments):
+For convenience, all subsequent examples will use the wrapper syntax.
 
-    ssm -i i-01234567,i-98765432 --profile <aws-profile> -c ls
+The syntax for using the `repl` command is:
 
-## Arguments
+```
+ssm repl --profile <aws-profile> -t <app>,<stack>,<stage>
+```
 
-Refer to the program's help to see the required arguments, but here is
-some info about some of them.
-
-Note that the AWS profile to use is required, while region will
-default to `eu-west-1` (Ireland). You are also required to provide
-the name of [an AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html)
-that is used to authenticate AWS API calls.
-
-### Execution targets
-
-`ssm` needs to be told which instances should execute the provided
-command(s). You can do this by specifying instance IDs, or by
-specifying App, Stack, and Stage tags.
-
-    # by ID
-	... --instances i-0123456,i-9876543
-    ... -i i-0123456,i-9876543
-	
-	# by tag
-	... --asset-tags <app>,<stack>,<stage>
-	... -t <app>,<stack>,<stage>
-
-If you provide tags, `ssm` will search for running instances that are
-have those tags.
-
-## Actions
-
-### One-Off Commands
-
-You can tell `ssm` the commands to execute with an argument that
-specifies the command or by providing a file that contains the
-commands to be run.
-
-    # specify command
-	--cmd ls
-	-c ls
-	
-	# provide script file
-	--src-file script
-	-f script
-
-### Command Loop (REPL)
-
-With the `-I` interactive flag, `ssm` will initialise a list of
+This causes `ssm` to generate a list of
 instances and then wait for commands to be specified.  Each command
 will be executed on all instances and the user can select the instance
 to display.
 
-### SSH
+The syntax for using the `ssh` command is:
 
-Specifying the `-s` flag will cause `ssm` to generate a temporary ssh
+```
+ssm ssh --profile <aws-profile> -t <app>,<stack>,<stage> 
+```
+
+This causes `ssm` to generate a temporary ssh
 key, and install the public key on a specific instance.  It will then
-output the command to `ssh` directly to that instance.
-
+output the command to `ssh` directly to that instance. 
 The instance must already have both a public IP address _and_
 appropriate security groups.
+
+### More usage examples
+
+Execute a command on all matching instances:
+
+```
+ssm cmd -c <command> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
+```
+
+Execute the contents of a script file on matching instances:
+
+```
+ssm --file <path-to-script> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
+```
+
+Execute `ls` on the specified instance:
+
+```
+ssm cmd -c ls --profile <aws-profile> --instances i-01234567
+```
+
+Execute `ls` on multiple specified instances (using the short form of
+the arguments):
+
+```
+ssm cmd -f <path-to-script> --profile <aws-profile> -i i-01234567,i-98765432
+```
+
+### Execution targets
+
+As seen in the previous section, `ssm` needs to be told which 
+instances should execute the provided
+command(s). You can do this by specifying instance IDs, or by
+specifying App, Stack, and Stage tags.
+
+```
+# by ID
+... --instances i-0123456,i-9876543
+... -i i-0123456,i-9876543
+
+# by tag
+... --asset-tags <app>,<stack>,<stage>
+... -t <app>,<stack>,<stage>
+```
+
+If you provide tags, `ssm` will search for running instances that are
+have those tags.
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Command: repl
 run SSM in interactive/repl mode
 
 Command: ssh
+create and upload a temporary ssh key
 ```
 
 The general syntax is 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -5,13 +5,34 @@ import java.io.File
 import com.amazonaws.regions.{Region, Regions}
 import scopt.OptionParser
 
+
 object ArgumentParser {
 
   val argParser: OptionParser[Arguments] = new OptionParser[Arguments]("ssm") {
+
     opt[String]('p', "profile").required()
       .action { (profile, args) =>
         args.copy(profile = Some(profile))
       } text "the AWS profile name to use for authenticating this execution"
+
+    opt[Seq[String]]('i', "instances")
+      .action { (instanceIds, args) =>
+        val instances = instanceIds.map(i => InstanceId(i)).toList
+        args.copy(executionTarget = Some(ExecutionTarget(instances = Some(instances))))
+      } text "specify the instance ID(s) on which the specified command(s) should execute"
+
+    opt[String]('t', "tags")
+      .validate { tagsStr =>
+        Logic.extractSASTags(tagsStr).map(_ => ())
+      }
+      .action { (tagsStr, args) =>
+        Logic.extractSASTags(tagsStr)
+          .fold(
+            _ => args,
+            ass => args.copy(executionTarget = Some(ExecutionTarget(ass = Some(ass))))
+          )
+      } text "search for instances by tag e.g. '--tags app,stack,stage'"
+
     opt[String]('r', "region").optional()
       .validate { region =>
         try {
@@ -24,46 +45,31 @@ object ArgumentParser {
       } action { (region, args) =>
       args.copy(region = Region.getRegion(Regions.fromName(region)))
     } text "AWS region name (defaults to eu-west-1)"
-    // TODO: make these args instead of opts
-    opt[Seq[String]]('i', "instances")
-      .action { (instanceIds, args) =>
-        val instances = instanceIds.map(i => InstanceId(i)).toList
-        args.copy(executionTarget = Some(ExecutionTarget(instances = Some(instances))))
-      } text "specify the instance ID(s) on which the specified command(s) should execute"
-    opt[String]('t', "asset-tags")
-      .validate { tagsStr =>
-        Logic.extractSASTags(tagsStr).map(_ => ())
-      }
-      .action { (tagsStr, args) =>
-        Logic.extractSASTags(tagsStr)
-          .fold(
-            _ => args,
-            ass => args.copy(executionTarget = Some(ExecutionTarget(ass = Some(ass))))
-          )
-      } text "search for instances by tag e.g. --asset-tags app,stack,stage"
-    opt[String]('c', "cmd")
-      .action { (command, args) =>
-        args.copy(toExecute = Some(ToExecute(cmdOpt = Some(command))))
-      } text "a (bash) command to execute"
-    opt[File]('f', "src-file")
-      .action { (file, args) =>
-        args.copy(toExecute = Some(ToExecute(scriptOpt = Some(file))))
-      } text "a file containing bash commands to execute"
-    opt[Unit]('I', "interactive")
-      .action { (_, args) =>
-        args.copy(interactive = true)
-      } text "run SSM in interactive mode"
-    opt[Unit]('s', "ssh")
-      .action { (_, args) =>
-        args.copy(ssh = true)
-      } text "create and upload a temporary ssh key"
+
+    cmd("cmd")
+      .action((_, c) => c.copy(mode = Some(SsmCmd)))
+      .text("execute a single (bash) command, or a file containing bash commands")
+      .children(
+        opt[String]('c', "cmd").optional()
+          .action((cmd, args) => args.copy(toExecute = Some(cmd)))
+          .text("a bash command to execute"),
+        opt[File]('f', "file").optional()
+          .action((file, args) => args.copy(toExecute = Some(Logic.generateScript(Right(file)))))
+          .text("a file containing bash commands to execute")
+      )
+
+    cmd("repl")
+      .action((_, c) => c.copy(mode = Some(SsmRepl)))
+      .text("run SSM in interactive/repl mode")
+
+    cmd("ssh")
+      .action((_, c) => c.copy(mode = Some(SsmSsh)))
+      .text("create and upload a temporary ssh key")
+
     checkConfig { args =>
-      if (args.toExecute.isEmpty && !args.interactive && !args.ssh) Left("You must provide cmd or src-file; or interactive; or ssh")
-      else if (args.toExecute.nonEmpty && args.interactive) Left("You cannot specify both cmd or src-file; and interactive")
-      else if (args.toExecute.nonEmpty && args.ssh) Left("You cannot specify both cmd or src-file; and ssh")
-      else if (args.interactive && args.ssh) Left("You cannot specify both interactive and ssh")
+      if (args.mode.isEmpty) Left("You must select a mode to use: cmd, repl or ssh")
+      else if (args.toExecute.isEmpty && args.mode.contains(SsmCmd)) Left("You must provide commands to execute (src-file or cmd)")
       else if (args.executionTarget.isEmpty) Left("You must provide a list of target instances; or Stack, Stage, App tags")
-      else if (args.profile.isEmpty) Left("You must provide a profile")
       else Right(())
     }
   }

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -3,7 +3,7 @@ package com.gu.ssm
 import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
 import com.gu.ssm.aws.{EC2, SSM}
-import com.gu.ssm.utils.attempt.{ArgumentsError, Attempt, FailedAttempt, Failure}
+import com.gu.ssm.utils.attempt.{ArgumentsError, Attempt, Failure}
 
 import scala.concurrent.ExecutionContext
 
@@ -19,22 +19,15 @@ object IO {
     }.getOrElse(Attempt.Left(Failure("Unable to resolve execution target", "You must provide an execution target (instance(s) or tags)", ArgumentsError)))
   }
 
-  def executeOnInstances(instances: List[InstanceId], username: String, toExecute: ToExecute, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
+  def executeOnInstances(instances: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
     for {
-      script <- Attempt.fromEither(Logic.generateScript(toExecute))
-      cmdId <- SSM.sendCommand(instances, script, username, client)
+      cmdId <- SSM.sendCommand(instances, cmd, username, client)
       results <- SSM.getCmdOutputs(instances, cmdId, client)
     } yield results
   }
 
-  def executeOnInstances(instances: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
-    executeOnInstances(instances, username, ToExecute(cmdOpt = Some(cmd)), client)
-  }
-
-  def installSshKey(instances: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
+  def installSshKey(instances: List[InstanceId], username: String, script: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
     for {
-      // Get the script first, so that we only tag if we are ready to go
-      script <- Attempt.fromEither(Logic.generateScript(ToExecute(cmdOpt = Some(cmd))))
       cmdId <- SSM.sendCommand(instances, script, username, client)
     } yield cmdId
   }

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -41,5 +41,4 @@ object IO {
 
   def tagAsTainted(instances: List[InstanceId], username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
     EC2.tagInstances(instances, "taintedBy", username, ec2Client)
-
 }

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -1,15 +1,15 @@
 package com.gu.ssm
 
-import com.gu.ssm.utils.attempt.{ArgumentsError, FailedAttempt, Failure}
+import java.io.File
 
 import scala.io.Source
 
 
 object Logic {
-  def generateScript(toExecute: ToExecute): Either[FailedAttempt, String] = {
-    val scriptSourceOpt = toExecute.scriptOpt.map(Source.fromFile(_, "UTF-8").mkString)
-    toExecute.cmdOpt.orElse(scriptSourceOpt).toRight {
-      Failure("No execution commands provided", "You must provide commands to execute (src-file or cmd)", ArgumentsError).attempt
+  def generateScript(toExecute: Either[String, File]): String = {
+    toExecute match {
+      case Right(script) => Source.fromFile(script, "UTF-8").mkString
+      case Left(cmd) => cmd
     }
   }
 

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -17,18 +17,18 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, Some(profile), region, mode)) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, Some(profile), region, Some(mode))) =>
         implicit val stsClient: AWSSecurityTokenServiceAsync = STS.client(profile, region)
         implicit val ssmClient: AWSSimpleSystemsManagementAsync = SSM.client(profile, region)
         implicit val ec2Client: AmazonEC2Async = EC2.client(profile, region)
 
         mode match {
-          case Some(SsmRepl) =>
+          case SsmRepl =>
             interactiveLoop(executionTarget)
-          case Some(SsmCmd) if toExecuteOpt.nonEmpty =>
+          case SsmCmd if toExecuteOpt.nonEmpty =>
             val toExecute = toExecuteOpt.get
             execute(executionTarget, toExecute)
-          case Some(SsmSsh) =>
+          case SsmSsh =>
             setUpSSH(executionTarget)
           case _ => fail()
         }
@@ -61,7 +61,7 @@ object Main {
   }
 
   def getSingleInstance(instances: List[Instance]): Either[FailedAttempt, List[InstanceId]] = {
-    if (instances.lengthCompare(1) != 0) Left(FailedAttempt(
+    if (instances.length != 1) Left(FailedAttempt(
       Failure(s"Unable to identify a single instance", s"Error choosing single instance, found ${instances.map(i => i.id.id).mkString(", ")}", UnhandledError, None, None)))
     else Right(instances.map(i => i.id))
   }

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -63,12 +63,12 @@ object SSH {
       | /bin/sed -i '/${authKey.replaceAll("/", "\\\\/")}/d' /home/ubuntu/.ssh/authorized_keys;
       |""".stripMargin
 
-  def sshCmd(tempFile: File, instance: Instance)(implicit ec: ExecutionContext): (InstanceId, Either[CommandStatus, CommandResult]) = {
+  def sshCmd(tempFile: File, instance: Instance)(implicit ec: ExecutionContext): (InstanceId, String) = {
     val cmd = s"""
       | # Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:
       | ssh -i ${tempFile.getCanonicalFile.toString} ubuntu@${instance.publicIpAddressOpt.get};
       |""".stripMargin
-    instance.id -> Right(CommandResult(cmd, ""))
+    instance.id -> cmd
   }
 
 }

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -8,7 +8,7 @@ object UI {
     results.foreach { case (instance, result) =>
       UI.printMetadata(s"========= ${instance.id} =========")
       if (result.isLeft) {
-        UI.printMetadata(result.left.get.toString)
+        UI.printErr(result.left.get.toString)
       } else {
         val output = result.right.get
         UI.printMetadata(s"STDOUT:")
@@ -16,6 +16,14 @@ object UI {
         UI.printMetadata(s"STDERR:")
         UI.printErr(output.stdErr)
       }
+    }
+  }
+
+  def sshOutput(results: List[(InstanceId, String)]): Unit = {
+    results.foreach { case (instance, cmd) =>
+      UI.printMetadata(s"========= ${instance.id} =========")
+      UI.printMetadata(s"STDOUT:")
+      println(cmd)
     }
   }
 

--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -33,7 +33,7 @@ object AwsAsyncHandler {
         Failure("Invalid AWS profile name (does not exist)", "The specified AWS profile does not exist", AwsPermissionsError).attempt
       } else if (e.getMessage.contains("is not authorized to perform")) {
         val message = serviceNameOpt.fold("You do not have sufficient AWS privileges")(serviceName => s"You do not have sufficient privileges to perform actions on $serviceName")
-        Failure("insuficient permissions", message, AwsPermissionsError).attempt
+        Failure("insufficient permissions", message, AwsPermissionsError).attempt
       } else if (e.getMessage.contains("InvalidInstanceId")) {
         Failure("InvalidInstanceId from AWS", "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)", AwsError).attempt
       } else {

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -45,7 +45,7 @@ object EC2 {
       reservation <- describeInstancesResult.getReservations.asScala
       awsInstance <- reservation.getInstances.asScala
       instanceId = awsInstance.getInstanceId
-    } yield Instance(InstanceId(awsInstance.getInstanceId), Option(awsInstance.getPublicIpAddress))).toList
+    } yield Instance(InstanceId(instanceId), Option(awsInstance.getPublicIpAddress))).toList
   }
 
   def tagInstances(ids:List[InstanceId], key: String, value: String, client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] = {

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -55,7 +55,7 @@ object SSM {
 
   def getCmdOutput(instance: InstanceId, commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[(InstanceId, Either[CommandStatus, CommandResult])] = {
     for {
-      initialDelay <- Attempt.delay(500.millis)
+      _ <- Attempt.delay(500.millis)
       cmdResult <- Attempt.retryUntil(30, 500.millis, () => getCommandInvocation(instance, commandId, client))(_.isRight)
     } yield instance -> cmdResult
   }

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -1,7 +1,5 @@
 package com.gu.ssm
 
-import java.io.File
-
 import com.amazonaws.regions.{Region, Regions}
 
 
@@ -10,11 +8,9 @@ case class Instance(id: InstanceId, publicIpAddressOpt: Option[String])
 case class AppStackStage(app: String, stack: String, stage: String)
 case class ExecutionTarget(instances: Option[List[InstanceId]] = None, ass: Option[AppStackStage] = None)
 
-case class ToExecute(cmdOpt: Option[String] = None, scriptOpt: Option[File] = None)
-
-case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[ToExecute], profile: Option[String], region: Region, interactive: Boolean, ssh: Boolean)
+case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[String], profile: Option[String], region: Region, mode: Option[SsmMode])
 object Arguments {
-  def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), false, false)
+  def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), None)
 }
 
 sealed trait CommandStatus
@@ -28,5 +24,10 @@ case object Failed extends CommandStatus
 case object Canceled extends CommandStatus
 case object Undeliverable extends CommandStatus
 case object Terminated extends CommandStatus
+
+sealed trait SsmMode
+case object SsmCmd extends SsmMode
+case object SsmRepl extends SsmMode
+case object SsmSsh extends SsmMode
 
 case class CommandResult(stdOut: String, stdErr: String)

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -33,15 +33,11 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     import Logic.generateScript
 
     "returns command if it was provided" in {
-      generateScript(ToExecute(cmdOpt = Some("ls"))).right.value shouldEqual "ls"
+      generateScript(Left("ls")) shouldEqual "ls"
     }
 
     "returns script contents if it was provided" ignore {
       // TODO: testing IO is hard, should extract file's content separately
-    }
-
-    "returns FailedAttempt if no command can be created" in {
-      generateScript(ToExecute(None, None)).left.value.failures.head.message shouldEqual "No execution commands provided"
     }
   }
 }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -51,11 +51,11 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
     import SSH.sshCmd
 
     "create ssh command" in {
-      val file:File = new File("/banana")
-      val instance:Instance = Instance(InstanceId("X"), Some("Y"))
+      val file: File = new File("/banana")
+      val instance: Instance = Instance(InstanceId("raspberry"), Some("127.0.0.1"))
       val cmd = sshCmd(file, instance)
-      cmd._1.id shouldEqual "X"
-      cmd._2.isRight shouldBe true
+      cmd._1.id shouldEqual "raspberry"
+      cmd._2 should include ("ssh -i /banana ubuntu@127.0.0.1")
     }
   }
 }


### PR DESCRIPTION
#### 👉 Switch to 'mode' selection and use commands to help with option parsing:

`ssm ssh -t app,stack,stage --profile awsprofile`

`ssm repl -t app,stack,stage --profile awsprofile`

`ssm cmd -c ls -t app,stack,stage --profile awsprofile`

<img width="942" alt="picture 164" src="https://user-images.githubusercontent.com/8607683/35334363-059f1ede-010a-11e8-8a2e-c1c7ff3d32ea.png">


#### 👉 Separate ssh UI
Separate UI with placeholder output when running the ssh command

#### 👉 Reduce the work and usage of generateScript
convert any cmd file from within the argParser, and just pass a string around from then on

#### 👉 Delete some checks on the config
the strict requirements on commands and some opts (profile) now make them unnecessary

#### 👉 Other minor fixes
Update the tests, delete unneeded methods, spelling, formatting, etc.


