### PR TITLE
UI Improvment: reporting erroneous instance ids while using cmd

### DIFF
--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -47,4 +47,7 @@ object Logic {
     AWSClients(ssmClient, stsClient, ec2Client)
   }
 
+  def computeIncorrectInstances(executionTarget: ExecutionTarget, results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])]): List[InstanceId] =
+    executionTarget.instances.getOrElse(List()).filterNot(results.map(_._1).toSet)
+
 }

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -52,15 +52,12 @@ object Main {
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 
-  private[ssm] def computeIncorrectInstances(executionTarget: ExecutionTarget, results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])]): List[InstanceId] =
-    executionTarget.instances.getOrElse(List()).filterNot(results.map(_._1).toSet)
-
   private def execute(awsClients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget, toExecute: String): Unit = {
     val fProgramResult = for {
       config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, profile, region, executionTarget)
       _ <- Attempt.fromEither(Logic.checkInstancesList(config))
       results <- IO.executeOnInstances(config.targets.map(i => i.id), config.name, toExecute, awsClients.ssmClient)
-      incorrectInstancesFromInstancesTag = computeIncorrectInstances(executionTarget, results)
+      incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(executionTarget, results)
     } yield ResultsWithInstancesNotFound(results,incorrectInstancesFromInstancesTag)
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.output)

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -75,6 +75,12 @@ object Main {
     val programResult = Await.result(fProgramResult.asFuture, 25.seconds)
 
     programResult.fold(UI.outputFailure, UI.output)
+
+    val leftOverInstances = executionTarget.instances.getOrElse(List()).filterNot(programResult.right.get.map(x => x._1).toSet)
+    if (leftOverInstances.nonEmpty) {
+      UI.printErr(s"The following instance(s) could not be found: ${leftOverInstances.map( x => x.id ).mkString(", ")}")
+    }
+
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -59,13 +59,12 @@ object Main {
       results <- IO.executeOnInstances(config.targets.map(i => i.id), config.name, toExecute, awsClients.ssmClient)
     } yield results
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
-    programResult.fold(UI.outputFailure, UI.output)
-
     val leftOverInstances = executionTarget.instances.getOrElse(List()).filterNot(programResult.right.get.map(x => x._1).toSet)
     if (leftOverInstances.nonEmpty) {
       UI.printErr(s"The following instance(s) could not be found: ${leftOverInstances.map( x => x.id ).mkString(", ")}")
+      UI.printErr("")
     }
-
+    programResult.fold(UI.outputFailure, UI.output)
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -52,7 +52,7 @@ object Main {
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 
-  private def computeIncorrectInstances(executionTarget: ExecutionTarget, results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])]): List[InstanceId] =
+  private[ssm] def computeIncorrectInstances(executionTarget: ExecutionTarget, results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])]): List[InstanceId] =
     executionTarget.instances.getOrElse(List()).filterNot(results.map(_._1).toSet)
 
   private def execute(awsClients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget, toExecute: String): Unit = {

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -4,8 +4,11 @@ import com.gu.ssm.utils.attempt.FailedAttempt
 
 
 object UI {
-  def output(results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])]): Unit = {
-    results.foreach { case (instance, result) =>
+  def output(extendedResults: ResultsWithInstancesNotFound): Unit = {
+    if(extendedResults.instancesNotFound.nonEmpty){
+      UI.printErr(s"The following instance(s) could not be found: ${extendedResults.instancesNotFound.map(_.id).mkString(", ")}\n")
+    }
+    extendedResults.results.foreach { case (instance, result) =>
       UI.printMetadata(s"========= ${instance.id} =========")
       if (result.isLeft) {
         UI.printErr(result.left.get.toString)

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -46,3 +46,5 @@ case class AWSClients (
   stsClient: AWSSecurityTokenServiceAsync,
   ec2Client: AmazonEC2Async
 )
+
+case class ResultsWithInstancesNotFound(results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])], instancesNotFound: List[InstanceId])

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -7,12 +7,12 @@ import com.gu.ssm.Main.computeIncorrectInstances
 class MainTest extends FreeSpec with Matchers with EitherValues {
 
   "computeIncorrectInstances" - {
-    "compute correct difference 1" in {
+    "should return empty list when matching list of Instance Ids" in {
       val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"))))
       val results = List((InstanceId("i-096fdd62fd48b5b99"), Right(CommandResult("", "")) ))
       computeIncorrectInstances(executionTarget, results) shouldEqual Nil
     }
-    "compute correct difference 2" in {
+    "should return incorrectly submitted Instance Id" in {
       val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"),InstanceId("i-12345"))))
       val results = List((InstanceId("i-096fdd62fd48b5b99"), Right(CommandResult("", "")) ))
       computeIncorrectInstances(executionTarget, results) shouldEqual List(InstanceId("i-12345"))

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -1,8 +1,22 @@
 package com.gu.ssm
 
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import com.gu.ssm.Main.computeIncorrectInstances
 
 
 class MainTest extends FreeSpec with Matchers with EitherValues {
+
+  "computeIncorrectInstances" - {
+    "compute correct difference 1" in {
+      val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"))))
+      val results = List((InstanceId("i-096fdd62fd48b5b99"), Right(CommandResult("", "")) ))
+      computeIncorrectInstances(executionTarget, results) shouldEqual Nil
+    }
+    "compute correct difference 2" in {
+      val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"),InstanceId("i-12345"))))
+      val results = List((InstanceId("i-096fdd62fd48b5b99"), Right(CommandResult("", "")) ))
+      computeIncorrectInstances(executionTarget, results) shouldEqual List(InstanceId("i-12345"))
+    }
+  }
 
 }

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -1,7 +1,7 @@
 package com.gu.ssm
 
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
-import com.gu.ssm.Main.computeIncorrectInstances
+import com.gu.ssm.Logic.computeIncorrectInstances
 
 
 class MainTest extends FreeSpec with Matchers with EitherValues {

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -6,6 +6,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 
 class SSHTest extends FreeSpec with Matchers with EitherValues {
+
   "create add key command" - {
     import SSH.addKeyCommand
 


### PR DESCRIPTION
With this change while running

```
$ java -jar ./ssm.jar cmd -c ls --profile security --instances i-011a0282bac767f41,i-09d626a5abdfb5c74,i-123456
```

where only the fist instance id (`i-011a0282bac767f41`) is correct, the output now becomes

```
The following instance(s) could not be found: i-09d626a5abdfb5c74, i-123456

========= i-011a0282bac767f41 =========
STDOUT:
amazon-ssm-agent.deb
bin
(...)
vmlinuz

STDERR:

```