### PR TITLE
UI Improvment: reporting erroneous instance ids while using repl

### DIFF
--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -27,7 +27,7 @@ class InteractiveProgram(val awsClients: AWSClients)(implicit ec: ExecutionConte
 
     configAttempt.onComplete {
       case Right(SSMConfig(targets, name)) => {
-        val incorrectInstancesFromInstancesTag = executionTarget.instances.getOrElse(Nil).filterNot(targets.map(i => i.id).toSet)
+        val incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(executionTarget, targets.map(i => i.id))
         ui.ready(targets.map(i => i.id), name, incorrectInstancesFromInstancesTag)
       }
       case Left(failedAttempt) =>
@@ -159,14 +159,14 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
   def ready(instances: List[InstanceId], username: String, instancesToReport: List[InstanceId]): Unit = {
     logger.trace("resolved instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(instances, username, ResultsWithInstancesNotFound(Nil,instancesToReport)))
+    textGUI.addWindow(mainWindow(instances, username, ResultsWithInstancesNotFound(Nil, instancesToReport)))
     textGUI.updateScreen()
   }
 
   def searching(): Unit = {
     logger.trace("waiting to resolve instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(List(), "", ResultsWithInstancesNotFound(Nil,Nil)))
+    textGUI.addWindow(mainWindow(List(), "", ResultsWithInstancesNotFound(Nil, Nil)))
     textGUI.updateScreen()
   }
 

--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -88,6 +88,13 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
     }
     contentPanel.addComponent(cmdInput)
 
+    val leftOverInstances = executionTarget.instances.getOrElse(List()).filterNot(instances.toSet)
+    if (leftOverInstances.nonEmpty) {
+      contentPanel.addComponent(new EmptySpace())
+      contentPanel.addComponent((new Label(s"The following instance(s) could not be found: ${leftOverInstances.map(_.id).mkString(", ")}")).setForegroundColor(TextColor.ANSI.RED))
+      contentPanel.addComponent(new EmptySpace())
+    }
+
     // show results, if present
     if (results.nonEmpty) {
       val outputs = results.zipWithIndex.map { case ((_, result), i) =>
@@ -114,12 +121,6 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
       contentPanel.addComponent(new Separator(Direction.HORIZONTAL))
       contentPanel.addComponent(errOutputBox)
       contentPanel.addComponent(stdOutputBox)
-    }
-
-    val leftOverInstances = executionTarget.instances.getOrElse(List()).filterNot(instances.toSet)
-    if (leftOverInstances.nonEmpty) {
-      contentPanel.addComponent(new EmptySpace())
-      contentPanel.addComponent((new Label(s"The following instance(s) could not be found: ${leftOverInstances.map(_.id).mkString(", ")}")).setForegroundColor(TextColor.ANSI.RED))
     }
 
     // close button

--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -16,7 +16,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class InteractiveProgram(client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext) extends LazyLogging {
   val ui = new InteractiveUI(this)
 
-  def main(setupAttempt: Attempt[(List[Instance], String)])(implicit ec: ExecutionContext): Unit = {
+  def main(executionTarget: ExecutionTarget, setupAttempt: Attempt[(List[Instance], String)])(implicit ec: ExecutionContext): Unit = {
+
     // start UI on a new thread (it blocks while it listens for keyboard input)
     Future {
       ui.start()
@@ -24,7 +25,7 @@ class InteractiveProgram(client: AWSSimpleSystemsManagementAsync)(implicit ec: E
     // update UI when we're ready to get started
     setupAttempt.onComplete {
       case Right((instances, username)) =>
-        ui.ready(instances.map(i => i.id), username)
+        ui.ready(executionTarget, instances.map(i => i.id), username)
       case Left(fa) =>
         ui.displayError(fa)
     }
@@ -33,10 +34,10 @@ class InteractiveProgram(client: AWSSimpleSystemsManagementAsync)(implicit ec: E
   /**
     * Kick off execution of a new command and update UI when it returns
     */
-  def executeCommand(command: String, instances: List[InstanceId], username: String): Unit = {
+  def executeCommand(executionTarget: ExecutionTarget, command: String, instances: List[InstanceId], username: String): Unit = {
     IO.executeOnInstances(instances, username, command, client).onComplete {
       case Right(results) =>
-        ui.displayResults(instances, username, results)
+        ui.displayResults(executionTarget, instances, username, results)
       case Left(fa) =>
         ui.displayError(fa)
     }
@@ -57,7 +58,7 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
   /**
     * Create window that displays the main UI along with the results of the previous command
     */
-  def mainWindow(instances: List[InstanceId], username: String, results: List[(InstanceId, Either[CommandStatus, CommandResult])]): BasicWindow = {
+  def mainWindow(executionTarget: ExecutionTarget, instances: List[InstanceId], username: String, results: List[(InstanceId, Either[CommandStatus, CommandResult])]): BasicWindow = {
     val window = new BasicWindow(username)
 
     val initialSize = screen.getTerminal.getTerminalSize
@@ -76,7 +77,7 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
       override def handleKeyStroke(keyStroke: KeyStroke): Result = {
         keyStroke.getKeyType match {
           case KeyType.Enter =>
-            program.executeCommand(this.getText, instances, username)
+            program.executeCommand(executionTarget, this.getText, instances, username)
             val loading = WaitingDialog.createDialog("Executing...", "Executing command on instances")
             textGUI.addWindow(loading)
             Result.HANDLED
@@ -115,6 +116,12 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
       contentPanel.addComponent(stdOutputBox)
     }
 
+    val leftOverInstances = executionTarget.instances.getOrElse(List()).filterNot(instances.toSet)
+    if (leftOverInstances.nonEmpty) {
+      contentPanel.addComponent(new EmptySpace())
+      contentPanel.addComponent((new Label(s"The following instance(s) could not be found: ${leftOverInstances.map(_.id).mkString(", ")}")).setForegroundColor(TextColor.ANSI.RED))
+    }
+
     // close button
     contentPanel.addComponent(new EmptySpace())
     contentPanel.addComponent(new Separator(Direction.HORIZONTAL))
@@ -141,17 +148,17 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
     textGUI.addWindowAndWait(window)
   }
 
-  def ready(instances: List[InstanceId], username: String): Unit = {
+  def ready(executionTarget: ExecutionTarget, instances: List[InstanceId], username: String): Unit = {
     logger.trace("resolved instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(instances, username, Nil))
+    textGUI.addWindow(mainWindow(executionTarget, instances, username, Nil))
     textGUI.updateScreen()
   }
 
-  def displayResults(instances: List[InstanceId], username: String, results: List[(InstanceId, Either[CommandStatus, CommandResult])]): Unit = {
+  def displayResults(executionTarget: ExecutionTarget, instances: List[InstanceId], username: String, results: List[(InstanceId, Either[CommandStatus, CommandResult])]): Unit = {
     logger.trace("displaying results")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(instances, username, results))
+    textGUI.addWindow(mainWindow(executionTarget, instances, username, results))
     textGUI.updateScreen()
   }
 

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -47,7 +47,8 @@ object Logic {
     AWSClients(ssmClient, stsClient, ec2Client)
   }
 
-  def computeIncorrectInstances(executionTarget: ExecutionTarget, results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])]): List[InstanceId] =
-    executionTarget.instances.getOrElse(List()).filterNot(results.map(_._1).toSet)
+  def computeIncorrectInstances(executionTarget: ExecutionTarget, instanceIds: List[InstanceId]): List[InstanceId] =
+    executionTarget.instances.getOrElse(List()).filterNot(instanceIds.toSet)
+
 
 }

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -57,7 +57,7 @@ object Main {
       config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, profile, region, executionTarget)
       _ <- Attempt.fromEither(Logic.checkInstancesList(config))
       results <- IO.executeOnInstances(config.targets.map(i => i.id), config.name, toExecute, awsClients.ssmClient)
-      incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(executionTarget, results)
+      incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(executionTarget, results.map(_._1))
     } yield ResultsWithInstancesNotFound(results,incorrectInstancesFromInstancesTag)
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.output)

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -84,6 +84,6 @@ object Main {
       STS.getCallerIdentity(stsClient)
     )((_, _))
     val interactive = new InteractiveProgram(ssmClient)(ec)
-    interactive.main(configAttempt)
+    interactive.main(executionTarget,configAttempt)
   }
 }

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -84,6 +84,7 @@ object Main {
       STS.getCallerIdentity(stsClient)
     )((_, _))
     val interactive = new InteractiveProgram(ssmClient)(ec)
-    interactive.main(executionTarget,configAttempt)
+    val userSubmittedInstanceIds = executionTarget.instances.getOrElse(Nil)
+    interactive.main(configAttempt,userSubmittedInstanceIds)
   }
 }

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -46,3 +46,5 @@ case class AWSClients (
   stsClient: AWSSecurityTokenServiceAsync,
   ec2Client: AmazonEC2Async
 )
+
+case class ResultsWithInstancesNotFound(results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])], instancesNotFound: List[InstanceId])

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -9,13 +9,13 @@ class MainTest extends FreeSpec with Matchers with EitherValues {
   "computeIncorrectInstances" - {
     "should return empty list when matching list of Instance Ids" in {
       val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"))))
-      val results = List((InstanceId("i-096fdd62fd48b5b99"), Right(CommandResult("", "")) ))
-      computeIncorrectInstances(executionTarget, results) shouldEqual Nil
+      val instanceIds = List(InstanceId("i-096fdd62fd48b5b99"))
+      computeIncorrectInstances(executionTarget, instanceIds) shouldEqual Nil
     }
     "should return incorrectly submitted Instance Id" in {
       val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"),InstanceId("i-12345"))))
-      val results = List((InstanceId("i-096fdd62fd48b5b99"), Right(CommandResult("", "")) ))
-      computeIncorrectInstances(executionTarget, results) shouldEqual List(InstanceId("i-12345"))
+      val instanceIds = List(InstanceId("i-096fdd62fd48b5b99"))
+      computeIncorrectInstances(executionTarget, instanceIds) shouldEqual List(InstanceId("i-12345"))
     }
   }
 


### PR DESCRIPTION
We now report in the repl screen that some instances could not be found. 
This is the sister PR of: https://github.com/guardian/ssm-scala/pull/13

Running 

```
$ java -jar ./ssm.jar repl --profile security --instances i-04d908c9a645cd264,i-123456
```

where the only valid id is `i-04d908c9a645cd264`, we get

![screen shot 2018-01-30 at 14 00 13](https://user-images.githubusercontent.com/6035518/35570217-7c8cab22-05c6-11e8-9c9d-58d20d2528e0.png)

The following screenshot shows the error message shown after the command having been ran ( `i-049447ce9628d26fe` was correct instance id and `i-123456` an incorrect one )

![screen shot 2018-01-30 at 15 11 27](https://user-images.githubusercontent.com/6035518/35573982-81960d2a-05d0-11e8-9e35-68a0ce9dcb26.png)

This change contains few function signatures changes to carry `executionTarget` where it wasn't originally available. 