### PR TITLE
Simplify use by providing an executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,7 @@ Instructions for using SSM Scala in your own project can be found [below](#How-t
 
 ## Installation
 
-Fetch the most recently released version of the program from the
-Github releases page
-
-[Permalink to latest release](https://github.com/guardian/ssm-scala/releases/latest)
-
-You can then write a simple wrapper script and put it on your path:
-
-    java -jar <path-to-jar>/ssm.jar "$@"
-
-Call it `ssm` and make sure it is executable (`chmod +x ssm`).
+Fetch the most recently released version of the program from the [Github releases page](https://github.com/guardian/ssm-scala/releases/latest) and make sure it is executable (`chmod +x ssm`).
 
 ## Usage
 
@@ -47,19 +38,13 @@ create and upload a temporary ssh key
 The general syntax is 
 
 ```
-ssm [cmd|repl|ssh] [options]
+./ssm [cmd|repl|ssh] [options]
 ```
 
-An example of `cmd` (from the same folder where `ssm.jar` is located) is 
+An example of `cmd` is 
 
 ```
-java -jar ./ssm.jar cmd -c ls --profile security -t security-hq,security,PROD
-```
-
-... but, as per advised in the **Installation** section, if you have the `ssm` wrapper set up this can be rewritten 
-
-```
-ssm cmd -c ls --profile security -t security-hq,security,PROD
+./ssm cmd -c ls --profile security -t security-hq,security,PROD
 ```
 
 For more information about `--profile` see [AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
@@ -71,7 +56,7 @@ For convenience, all subsequent examples will use the wrapper syntax.
 The syntax for using the `repl` command is:
 
 ```
-ssm repl --profile <aws-profile> -t <app>,<stack>,<stage>
+./ssm repl --profile <aws-profile> -t <app>,<stack>,<stage>
 ```
 
 This causes `ssm` to generate a list of
@@ -82,7 +67,7 @@ to display.
 The syntax for using the `ssh` command is:
 
 ```
-ssm ssh --profile <aws-profile> -t <app>,<stack>,<stage> 
+./ssm ssh --profile <aws-profile> -t <app>,<stack>,<stage> 
 ```
 
 This causes `ssm` to generate a temporary ssh
@@ -96,26 +81,26 @@ appropriate security groups.
 Execute a command on all matching instances:
 
 ```
-ssm cmd -c <command> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
+./ssm cmd -c <command> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
 ```
 
 Execute the contents of a script file on matching instances:
 
 ```
-ssm --file <path-to-script> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
+./ssm --file <path-to-script> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
 ```
 
 Execute `ls` on the specified instance:
 
 ```
-ssm cmd -c ls --profile <aws-profile> --instances i-01234567
+./ssm cmd -c ls --profile <aws-profile> --instances i-01234567
 ```
 
 Execute `ls` on multiple specified instances (using the short form of
 the arguments):
 
 ```
-ssm cmd -f <path-to-script> --profile <aws-profile> -i i-01234567,i-98765432
+./ssm cmd -f <path-to-script> --profile <aws-profile> -i i-01234567,i-98765432
 ```
 
 ### Execution targets
@@ -149,20 +134,17 @@ sbt shell or from the CLI in that project.
     sbt:ssm-scala> run --instances i-0123456 --profile xxx --region xxx --cmd pwd
 
 However, `sbt` traps the program exit so in REPL mode you may find it
-easier to create and run a jar instead.
+easier to create and run an executable instead, for this just run 
 
-You can produce a `jar` from your current source code using `assembly`
-from the sbt shell, or by executing the following from within the
-project. The command's output will show the location of the newly
-created jar file, but it's likely to be in `target/scala-2.12/ssm.jar`
+```
+./generate-executable.sh
+```
 
-    sbt assembly
+The result of this script is an executable called `ssm` in the target folder. If you are using a non unix operating system, run `sbt assembly` as you would normally do and then run the ssm.jar file using 
 
-The jar can then be invoked as follows (it may be useful to create a
-wrapper script, as described above in 'Installation').
-
-    java -jar <path-to-jar>/ssm.jar "@$"
-
+```
+java -jar <path-to-jar>/ssm.jar [arguments]
+```
 
 ## How to use SSM Scala with your own project
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Instructions for using SSM Scala in your own project can be found [below](#How-t
 
 ## Installation
 
-Fetch the most recently released version of the program from the [Github releases page](https://github.com/guardian/ssm-scala/releases/latest) and make sure it is executable (`chmod +x ssm`).
+Fetch the most recently released version of the program from the [Github releases page](https://github.com/guardian/ssm-scala/releases/latest) and make sure it is executable (`chmod +x ssm`). You may then want to put it somewhere in your PATH.
 
 ## Usage
 

--- a/generate-executable-prefix
+++ b/generate-executable-prefix
@@ -1,0 +1,9 @@
+#!/bin/sh
+MYSELF=`which "$0" 2>/dev/null`
+[ $? -gt 0 -a -f "$0" ] && MYSELF="./$0"
+java=java
+if test -n "$JAVA_HOME"; then
+    java="$JAVA_HOME/bin/java"
+fi
+exec "$java" -jar $MYSELF "$@"
+exit $?

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
 sbt assembly
-cat generate-executable-prefix target/scala-2.12/ssm.jar > target/scala-2.12/ssm 
-chmod +x target/scala-2.12/ssm
-echo "ssm executable now available at target/scala-2.12/ssm"
+cat "$DIR/generate-executable-prefix" "$DIR/target/scala-2.12/ssm.jar" > "$DIR/target/scala-2.12/ssm" 
+chmod +x "$DIR/target/scala-2.12/ssm"
+echo "ssm executable now available at $DIR/target/scala-2.12/ssm"

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+sbt assembly
+cat generate-executable-prefix target/scala-2.12/ssm.jar > target/scala-2.12/ssm 
+chmod +x target/scala-2.12/ssm
+echo "ssm executable now available at target/scala-2.12/ssm"


### PR DESCRIPTION
This change introduces `generate-executable.sh` which can now be used to generate single executable called `ssm`. The documentation has been updated accordingly.