### PR TITLE
New (optional) command line argument in the case of the ssh command: -a, --any <boolean>

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,23 @@ The automatically generated help section for `ssm` is
 
 ```
 Usage: ssm [cmd|repl|ssh] [options]
-  -p, --profile <value>    the AWS profile name to use for authenticating this execution
-  -i, --instances <value>  specify the instance ID(s) on which the specified command(s) should execute
-  -t, --tags <value>       search for instances by tag e.g. '--tags app,stack,stage'
+
+  -p, --profile <value>    The AWS profile name to use for authenticating this execution
+  -i, --instances <value>  Specify the instance ID(s) on which the specified command(s) should execute
+  -t, --tags <value>       Search for instances by tag e.g. '--tags app,stack,stage'
   -r, --region <value>     AWS region name (defaults to eu-west-1)
 
 Command: cmd [options]
-execute a single (bash) command, or a file containing bash commands
-  -c, --cmd <value>        a bash command to execute
-  -f, --file <value>       a file containing bash commands to execute
+Execute a single (bash) command, or a file containing bash commands
+  -c, --cmd <value>        A bash command to execute
+  -f, --file <value>       A file containing bash commands to execute
 
 Command: repl
-run SSM in interactive/repl mode
+Run SSM in interactive/repl mode
 
-Command: ssh
-create and upload a temporary ssh key
+Command: ssh [options]
+Create and upload a temporary ssh key
+  -a, --any <value>        Indicates whether the command should run on any single instance
 ```
 
 The general syntax is 
@@ -75,6 +77,8 @@ key, and install the public key on a specific instance.  It will then
 output the command to `ssh` directly to that instance. 
 The instance must already have both a public IP address _and_
 appropriate security groups.
+
+Notet that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to process with one single instance with the argument `-a true`.
 
 ### More usage examples
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ output the command to `ssh` directly to that instance.
 The instance must already have both a public IP address _and_
 appropriate security groups.
 
-Notet that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to process with one single instance with the argument `-a true`.
+Note that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to process with one single instance with the argument `-a true`.
 
 ### More usage examples
 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -13,13 +13,13 @@ object ArgumentParser {
     opt[String]('p', "profile").required()
       .action { (profile, args) =>
         args.copy(profile = Some(profile))
-      } text "the AWS profile name to use for authenticating this execution"
+      } text "The AWS profile name to use for authenticating this execution"
 
     opt[Seq[String]]('i', "instances")
       .action { (instanceIds, args) =>
         val instances = instanceIds.map(i => InstanceId(i)).toList
         args.copy(executionTarget = Some(ExecutionTarget(instances = Some(instances))))
-      } text "specify the instance ID(s) on which the specified command(s) should execute"
+      } text "Specify the instance ID(s) on which the specified command(s) should execute"
 
     opt[String]('t', "tags")
       .validate { tagsStr =>
@@ -31,7 +31,7 @@ object ArgumentParser {
             _ => args,
             ass => args.copy(executionTarget = Some(ExecutionTarget(ass = Some(ass))))
           )
-      } text "search for instances by tag e.g. '--tags app,stack,stage'"
+      } text "Search for instances by tag e.g. '--tags app,stack,stage'"
 
     opt[String]('r', "region").optional()
       .validate { region =>
@@ -48,23 +48,28 @@ object ArgumentParser {
 
     cmd("cmd")
       .action((_, c) => c.copy(mode = Some(SsmCmd)))
-      .text("execute a single (bash) command, or a file containing bash commands")
+      .text("Execute a single (bash) command, or a file containing bash commands")
       .children(
         opt[String]('c', "cmd").optional()
           .action((cmd, args) => args.copy(toExecute = Some(cmd)))
-          .text("a bash command to execute"),
+          .text("A bash command to execute"),
         opt[File]('f', "file").optional()
           .action((file, args) => args.copy(toExecute = Some(Logic.generateScript(Right(file)))))
-          .text("a file containing bash commands to execute")
+          .text("A file containing bash commands to execute")
       )
 
     cmd("repl")
       .action((_, c) => c.copy(mode = Some(SsmRepl)))
-      .text("run SSM in interactive/repl mode")
+      .text("Run SSM in interactive/repl mode")
 
     cmd("ssh")
       .action((_, c) => c.copy(mode = Some(SsmSsh)))
-      .text("create and upload a temporary ssh key")
+      .text("Create and upload a temporary ssh key")
+      .children(
+        opt[Boolean]('a', "any").optional()
+          .action((flag, args) => args.copy(takeAnySingleInstance = Some(flag)))
+          .text("Indicates whether the command should run on any single instance"),
+      )
 
     checkConfig { args =>
       if (args.mode.isEmpty) Left("You must select a mode to use: cmd, repl or ssh")

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -21,21 +21,21 @@ object IO {
     }.getOrElse(Attempt.Left(Failure("Unable to resolve execution target", "You must provide an execution target (instance(s) or tags)", ArgumentsError)))
   }
 
-  def executeOnInstances(instances: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
+  def executeOnInstances(instanceIds: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
     for {
-      cmdId <- SSM.sendCommand(instances, cmd, username, client)
-      results <- SSM.getCmdOutputs(instances, cmdId, client)
+      cmdId <- SSM.sendCommand(instanceIds, cmd, username, client)
+      results <- SSM.getCmdOutputs(instanceIds, cmdId, client)
     } yield results
   }
 
-  def installSshKey(instances: List[InstanceId], username: String, script: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
+  def installSshKey(instanceId: InstanceId, username: String, script: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
     for {
-      cmdId <- SSM.sendCommand(instances, script, username, client)
+      cmdId <- SSM.sendCommand(List(instanceId), script, username, client)
     } yield cmdId
   }
 
-  def tagAsTainted(instances: List[InstanceId], username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
-    EC2.tagInstances(instances, "taintedBy", username, ec2Client)
+  def tagAsTainted(instance: InstanceId, username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
+    EC2.tagInstance(instance, "taintedBy", username, ec2Client)
 
   def getSSMConfig(ec2Client: AmazonEC2Async, stsClient: AWSSecurityTokenServiceAsync, profile: String, region: Region, executionTarget: ExecutionTarget)(implicit ec: ExecutionContext): Attempt[SSMConfig] = {
     for {

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -35,9 +35,23 @@ object Logic {
   }
 
   def getSingleInstance(instances: List[Instance]): Either[FailedAttempt, List[InstanceId]] = {
-    if (instances.lengthCompare(1) != 0) Left(FailedAttempt(
+    if (instances.length != 1) Left(FailedAttempt(
       Failure(s"Unable to identify a single instance", s"Error choosing single instance, found ${instances.map(i => i.id.id).mkString(", ")}", UnhandledError, None, None)))
     else Right(instances.map(i => i.id))
+  }
+
+  def getFirstInstance(instances: List[Instance]): Either[FailedAttempt, List[InstanceId]] = {
+    if (instances.length == 0) Left(FailedAttempt(
+      Failure(s"Unable to identify a single instance", s"Could not find any instance", UnhandledError, None, None)))
+    else Right(instances.map(i => i.id).take(1))
+  }
+
+  def getRelevantInstancesAsEither(instances: List[Instance], takeAnySingleInstance: Boolean): Either[FailedAttempt, List[InstanceId]] = {
+    if (takeAnySingleInstance) getFirstInstance(instances) else getSingleInstance(instances)
+  }
+
+  def getRelevantInstancesAsList(instances: List[Instance], takeAnySingleInstance: Boolean): List[Instance] = {
+    if (takeAnySingleInstance) instances.take(1) else instances
   }
 
   def getClients(profile: String, region: Region): AWSClients = {

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -43,7 +43,7 @@ object Logic {
   def getFirstInstance(instances: List[Instance]): Either[FailedAttempt, List[InstanceId]] = {
     if (instances.length == 0) Left(FailedAttempt(
       Failure(s"Unable to identify a single instance", s"Could not find any instance", UnhandledError, None, None)))
-    else Right(instances.map(i => i.id).take(1))
+    else Right(instances.map(i => i.id).sortWith( (i1,i2) => i1.id < i2.id ).take(1))
   }
 
   def getRelevantInstancesAsEither(instances: List[Instance], takeAnySingleInstance: Boolean): Either[FailedAttempt, List[InstanceId]] = {
@@ -51,7 +51,7 @@ object Logic {
   }
 
   def getRelevantInstancesAsList(instances: List[Instance], takeAnySingleInstance: Boolean): List[Instance] = {
-    if (takeAnySingleInstance) instances.take(1) else instances
+    if (takeAnySingleInstance) instances.sortWith( (i1,i2) => i1.id.id < i2.id.id ).take(1) else instances
   }
 
   def getClients(profile: String, region: Region): AWSClients = {

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -42,10 +42,10 @@ object Main {
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (authFile, authKey) = sshArtifacts
       addAndRemoveKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addKeyCommand(authKey) + SSH.removeKeyCommand(authKey)
-      instance <- Attempt.fromEither(Logic.getRelevantInstancesAsEither(config.targets, takeAnySingleInstance))
-      _ <- IO.tagAsTainted(instance, config.name, awsClients.ec2Client)
-      _ <- IO.installSshKey(instance, config.name, addAndRemoveKeyCommand, awsClients.ssmClient)
-    } yield Logic.getRelevantInstancesAsList(config.targets,takeAnySingleInstance).map(SSH.sshCmd(authFile, _))
+      instance <- Attempt.fromEither(Logic.getRelevantInstance(config.targets, takeAnySingleInstance))
+      _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
+      _ <- IO.installSshKey(instance.id, config.name, addAndRemoveKeyCommand, awsClients.ssmClient)
+    } yield SSH.sshCmd(authFile, instance)
 
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput)

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -4,7 +4,6 @@ import java.io.{File, IOException}
 import java.security.{NoSuchAlgorithmException, NoSuchProviderException}
 import java.util.Calendar
 
-import scala.concurrent.ExecutionContext
 import com.gu.ssm.utils.attempt._
 import com.gu.ssm.utils.{KeyMaker, FilePermissions}
 
@@ -23,8 +22,6 @@ object SSH {
     try {
       val tempFile = File.createTempFile(prefix, suffix)
       FilePermissions(tempFile, "0600")
-
-
       val authKey = KeyMaker.makeKey(tempFile, keyAlgorithm, keyProvider)
       Right((tempFile, authKey))
     } catch {
@@ -63,12 +60,12 @@ object SSH {
       | /bin/sed -i '/${authKey.replaceAll("/", "\\\\/")}/d' /home/ubuntu/.ssh/authorized_keys;
       |""".stripMargin
 
-  def sshCmd(tempFile: File, instance: Instance)(implicit ec: ExecutionContext): (InstanceId, String) = {
+  def sshCmd(tempFile: File, instance: Instance): (InstanceId, String) = {
     val cmd = s"""
       | # Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:
       | ssh -i ${tempFile.getCanonicalFile.toString} ubuntu@${instance.publicIpAddressOpt.get};
       |""".stripMargin
-    instance.id -> cmd
+    (instance.id, cmd)
   }
 
 }

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -22,12 +22,10 @@ object UI {
     }
   }
 
-  def sshOutput(results: List[(InstanceId, String)]): Unit = {
-    results.foreach { case (instance, cmd) =>
-      UI.printMetadata(s"========= ${instance.id} =========")
-      UI.printMetadata(s"STDOUT:")
-      println(cmd)
-    }
+  def sshOutput(results: (InstanceId, String)): Unit = {
+    UI.printMetadata(s"========= ${results._1.id} =========")
+    UI.printMetadata(s"STDOUT:")
+    println(results._2)
   }
 
   def outputFailure(failedAttempt: FailedAttempt): Unit = {

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -48,10 +48,10 @@ object EC2 {
     } yield Instance(InstanceId(instanceId), Option(awsInstance.getPublicIpAddress))).toList
   }
 
-  def tagInstances(ids:List[InstanceId], key: String, value: String, client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] = {
+  def tagInstance(id: InstanceId, key: String, value: String, client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] = {
     val request = new CreateTagsRequest()
       .withTags(new Tag(key, value))
-      .withResources(ids.map(_.id).asJava)
+      .withResources(id.id)
     handleAWSErrs(awsToScala(client.createTagsAsync)(request)).map(_ => Unit)
   }
 

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -21,11 +21,11 @@ object SSM {
       .build()
   }
 
-  def sendCommand(instances: List[InstanceId], cmd: String, username: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
+  def sendCommand(instanceIds: List[InstanceId], cmd: String, username: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
     val parameters = Map("commands" -> List(cmd).asJava).asJava
     val sendCommandRequest = new SendCommandRequest()
       .withComment(s"Command submitted by $username")
-      .withInstanceIds(instances.map(i => i.id).asJava)
+      .withInstanceIds(instanceIds.map(_.id).asJava)
       .withDocumentName("AWS-RunShellScript")
       .withParameters(parameters)
     handleAWSErrs(awsToScala(client.sendCommandAsync)(sendCommandRequest).map(extractCommandId))
@@ -60,8 +60,8 @@ object SSM {
     } yield instance -> cmdResult
   }
 
-  def getCmdOutputs(instances: List[InstanceId], commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
-    Attempt.traverse(instances)(getCmdOutput(_, commandId, client))
+  def getCmdOutputs(instanceIds: List[InstanceId], commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
+    Attempt.traverse(instanceIds)(getCmdOutput(_, commandId, client))
   }
 
   def commandStatus(statusDetail: String): CommandStatus = {

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -12,9 +12,9 @@ case class Instance(id: InstanceId, publicIpAddressOpt: Option[String])
 case class AppStackStage(app: String, stack: String, stage: String)
 case class ExecutionTarget(instances: Option[List[InstanceId]] = None, ass: Option[AppStackStage] = None)
 
-case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[String], profile: Option[String], region: Region, mode: Option[SsmMode])
+case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[String], profile: Option[String], region: Region, mode: Option[SsmMode], takeAnySingleInstance: Option[Boolean])
 object Arguments {
-  def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), None)
+  def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), None, Some(false))
 }
 
 sealed trait CommandStatus

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -2,7 +2,6 @@ package com.gu.ssm
 
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
 
-
 class LogicTest extends FreeSpec with Matchers with EitherValues {
   "extractSASTags" - {
     import Logic.extractSASTags
@@ -41,21 +40,31 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     }
   }
 
-  "Get single instance" - {
-    import Logic.getSingleInstance
-
-    "More than one instance" in {
-      getSingleInstance(List(Instance(InstanceId("X"), None), Instance(InstanceId("Y"), None))).isLeft shouldBe true
+  "getRelevantInstance" - {
+    import Logic.getRelevantInstance
+    val instanceIdX = InstanceId("X")
+    val instanceIdY = InstanceId("Y")
+    val instanceX = Instance(instanceIdX, None)
+    val instanceY = Instance(instanceIdY, None)
+    "should be Left if given no instances" in {
+      getRelevantInstance(List(), true).isLeft shouldBe true
     }
-
-    "No instances" in {
-      getSingleInstance(List()).isLeft shouldBe true
+    "with one instance given" - {
+      "should return passed argument if takeAnySingleInstance is true" in {
+        getRelevantInstance(List(instanceX), true) shouldBe Right(instanceX)
+      }
+      "should return passed argument if takeAnySingleInstance is false" in {
+        getRelevantInstance(List(instanceX), false) shouldBe Right(instanceX)
+      }
     }
-
-    "Exactly one instance" in {
-      getSingleInstance(List(Instance(InstanceId("X"), None))).isRight shouldBe true
+    "with two instances given" - {
+      "should select the first (in lexicographic order of InstanceId) if takeAnySingleInstance is true" in {
+        getRelevantInstance(List(instanceX, instanceY), true) shouldBe Right(instanceX)
+      }
+      "should be Left if takeAnySingleInstance is false" in {
+        getRelevantInstance(List(instanceX, instanceY), false).isLeft shouldBe true
+      }
     }
   }
-
 
 }


### PR DESCRIPTION

- Some minor stylistic updates in arguments documentation.
- Added a new (optional) command line argument in the case of the ssh command.
- Updated the code to process this extra argument.

The net result is that users can now specify that they want ssh to proceed with one single instance if more than one instances where found. (Request from the CAPI team).

```
$ ./ssm ssh -p security -t security-hq,security,PROD
Error choosing single instance, found i-09bab0e2ecef2b184, i-0792c00571352d0e4

$ ./ssm ssh -p security -t security-hq,security,PROD -a true
========= i-09bab0e2ecef2b184 =========
STDOUT:

 # Execute the following command within the next 30 seconds:
 ssh -i /private/var/folders/7b/djwwh2kd4m95smw88z4hvfnr0000gn/T/security_ssm-scala_temporary-rsa-private-key4611386747952826521.tmp ubuntu@34.245.57.216;

```

- Updated the README with the relevant information.