### PR TITLE
getRelevantInstance -> getSSHInstance

### DIFF
--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -34,8 +34,8 @@ object IO {
     } yield cmdId
   }
 
-  def tagAsTainted(instance: InstanceId, username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
-    EC2.tagInstance(instance, "taintedBy", username, ec2Client)
+  def tagAsTainted(instanceId: InstanceId, username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
+    EC2.tagInstance(instanceId, "taintedBy", username, ec2Client)
 
   def getSSMConfig(ec2Client: AmazonEC2Async, stsClient: AWSSecurityTokenServiceAsync, profile: String, region: Region, executionTarget: ExecutionTarget)(implicit ec: ExecutionContext): Attempt[SSMConfig] = {
     for {
@@ -43,5 +43,4 @@ object IO {
       name <- STS.getCallerIdentity(stsClient)
     } yield SSMConfig(instances, name)
   }
-
 }

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -11,7 +11,6 @@ import com.gu.ssm.utils.attempt.{ErrorCode, FailedAttempt, Failure, UnhandledErr
 
 import scala.io.Source
 
-
 object Logic {
   def generateScript(toExecute: Either[String, File]): String = {
     toExecute match {
@@ -34,14 +33,13 @@ object Logic {
     case _ => Right(Unit)
   }
 
-  def getRelevantInstance(instances: List[Instance], takeAnySingleInstance: Boolean): Either[FailedAttempt, Instance] = {
-    if (instances.length == 0) {
+  def getSSHInstance(instances: List[Instance], takeAnySingleInstance: Boolean): Either[FailedAttempt, Instance] = {
+    val instancesWithPublicIP = instances.filter(_.publicIpAddressOpt.isDefined)
+    if (instancesWithPublicIP.isEmpty) {
       Left(FailedAttempt(Failure(s"Unable to identify a single instance", s"Could not find any instance", UnhandledError, None, None)))
-    } else if (instances.length == 1) {
-      Right(instances.sortBy(_.id.id).head) // head safe as length is necessary > 0
     } else {
-      val sortedInstances = instances.sortBy(_.id.id)
-      if (takeAnySingleInstance) Right(sortedInstances.head) // head safe as length is necessary > 0
+      val sortedInstances = instancesWithPublicIP.sortBy(_.id.id)
+      if (instancesWithPublicIP.length==1 || takeAnySingleInstance) Right(sortedInstances.head)
       else Left(FailedAttempt(Failure(s"Unable to identify a single instance", s"Error choosing single instance, found ${sortedInstances.mkString(", ")}", UnhandledError, None, None)))
     }
   }
@@ -55,6 +53,5 @@ object Logic {
 
   def computeIncorrectInstances(executionTarget: ExecutionTarget, instanceIds: List[InstanceId]): List[InstanceId] =
     executionTarget.instances.getOrElse(List()).filterNot(instanceIds.toSet)
-
 
 }

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -47,7 +47,7 @@ object Logic {
           Right(instance)
         case instance :: _ if takeAnySingleInstance =>
           Right(instance)
-        case _ :: _ =>
+        case _ :: _ :: _ =>
           Left(FailedAttempt(Failure(s"Unable to identify a single instance", s"Error choosing single instance, found ${sortedValidInstances.map(_.id.id).mkString(", ")}", UnhandledError, None, None)))
       }
     }

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -42,7 +42,7 @@ object Main {
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (authFile, authKey) = sshArtifacts
       addAndRemoveKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addKeyCommand(authKey) + SSH.removeKeyCommand(authKey)
-      instance <- Attempt.fromEither(Logic.getRelevantInstance(config.targets, takeAnySingleInstance))
+      instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, takeAnySingleInstance))
       _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
       _ <- IO.installSshKey(instance.id, config.name, addAndRemoveKeyCommand, awsClients.ssmClient)
     } yield SSH.sshCmd(authFile, instance)

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -22,6 +22,8 @@ object SSH {
     try {
       val tempFile = File.createTempFile(prefix, suffix)
       FilePermissions(tempFile, "0600")
+
+
       val authKey = KeyMaker.makeKey(tempFile, keyAlgorithm, keyProvider)
       Right((tempFile, authKey))
     } catch {

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -22,8 +22,6 @@ object SSH {
     try {
       val tempFile = File.createTempFile(prefix, suffix)
       FilePermissions(tempFile, "0600")
-
-
       val authKey = KeyMaker.makeKey(tempFile, keyAlgorithm, keyProvider)
       Right((tempFile, authKey))
     } catch {

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -22,10 +22,10 @@ object UI {
     }
   }
 
-  def sshOutput(results: (InstanceId, String)): Unit = {
-    UI.printMetadata(s"========= ${results._1.id} =========")
+  def sshOutput(result: (InstanceId, String)): Unit = {
+    UI.printMetadata(s"========= ${result._1.id} =========")
     UI.printMetadata(s"STDOUT:")
-    println(results._2)
+    println(result._2)
   }
 
   def outputFailure(failedAttempt: FailedAttempt): Unit = {

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.simplesystemsmanagement.model._
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagementAsync, AWSSimpleSystemsManagementAsyncClientBuilder}
 import com.gu.ssm.{CommandStatus, _}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import com.gu.ssm.utils.attempt.{Attempt, FailedAttempt}
+import com.gu.ssm.utils.attempt.{Attempt}
 
 import collection.JavaConverters._
 import scala.concurrent.ExecutionContext

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -45,51 +45,77 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     import Logic.getSSHInstance
     val instanceIdX = InstanceId("X")
     val instanceIdY = InstanceId("Y")
-    val sip = Some("1278.0.0.1")
+    val instanceXWithoutIP = Instance(instanceIdX, None)
+    val instanceYWithoutIP = Instance(instanceIdY, None)
+    val instanceXWithIP = Instance(instanceIdX, Some("1278.0.0.1"))
+    val instanceYWithIP = Instance(instanceIdY, Some("1278.0.0.1"))
+
     "if given no instances, should be Left" in {
       getSSHInstance(List(), true).isLeft shouldBe true
     }
+
     "Given one instance" - {
+
       "Instance is ill-formed" - {
+        val oneInstanceWithoutIP = List(instanceXWithoutIP)
+
         "If takeAnySingleInstance is true, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, None)), true).isLeft shouldBe true
+          getSSHInstance(oneInstanceWithoutIP, true).isLeft shouldBe true
         }
+
         "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, None)), false).isLeft shouldBe true
+          getSSHInstance(oneInstanceWithoutIP, false).isLeft shouldBe true
         }
       }
+
       "Instance is well-formed" - {
+        val oneInstanceWithIP = List(instanceXWithIP)
+
         "If takeAnySingleInstance is true, returns argument" in {
-          getSSHInstance(List(Instance(instanceIdX, sip)), true) shouldBe Right(Instance(instanceIdX, sip))
+          getSSHInstance(oneInstanceWithIP, true).right.get shouldEqual instanceXWithIP
         }
+
         "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, sip)), false) shouldBe Right(Instance(instanceIdX, sip))
+          getSSHInstance(oneInstanceWithIP, false).right.get shouldEqual instanceXWithIP
         }
       }
     }
+
     "Given more than one instance" - {
+
       "All instances are ill-formed" - {
+        val twoInstancesWithIP = List(instanceYWithoutIP, instanceXWithoutIP)
+
         "If takeAnySingleInstance is true, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, None)), true).isLeft shouldBe true
+          getSSHInstance(twoInstancesWithIP, true).isLeft shouldBe true
         }
+
         "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, None)), false).isLeft shouldBe true
+          getSSHInstance(twoInstancesWithIP, false).isLeft shouldBe true
         }
       }
+
       "At least one instance is well formed" - {
+        val twoMixedInstances = List(instanceYWithoutIP, instanceXWithIP)
+
         "If takeAnySingleInstance is true, selects the well-formed instance" in {
-          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, sip)), true) shouldBe Right(Instance(instanceIdY, sip))
+          getSSHInstance(twoMixedInstances, true).right.get shouldEqual instanceXWithIP
         }
+
         "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, sip)), false) shouldBe Right(Instance(instanceIdY, sip))
+          getSSHInstance(twoMixedInstances, false).right.get shouldEqual instanceXWithIP
         }
       }
+
       "All instances are well formed" - {
+        val twoInstancesWithIP = List(instanceYWithIP, instanceXWithIP)
+
         "If takeAnySingleInstance is true, selects the first well-formed instance (in lexicographic order of InstanceId)" in {
-          getSSHInstance(List(Instance(instanceIdY, sip), Instance(instanceIdX, sip)), true) shouldBe Right(Instance(instanceIdX, sip))
+          getSSHInstance(twoInstancesWithIP, true).right.get shouldEqual instanceXWithIP
         }
+
         "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(List(Instance(instanceIdX, sip), Instance(instanceIdY, sip)), false).isLeft shouldBe true
+          getSSHInstance(twoInstancesWithIP, false).isLeft shouldBe true
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -2,6 +2,7 @@ package com.gu.ssm
 
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
 
+
 class LogicTest extends FreeSpec with Matchers with EitherValues {
   "extractSASTags" - {
     import Logic.extractSASTags
@@ -41,30 +42,56 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
   }
 
   "getRelevantInstance" - {
-    import Logic.getRelevantInstance
+    import Logic.getSSHInstance
     val instanceIdX = InstanceId("X")
     val instanceIdY = InstanceId("Y")
-    val instanceX = Instance(instanceIdX, None)
-    val instanceY = Instance(instanceIdY, None)
-    "should be Left if given no instances" in {
-      getRelevantInstance(List(), true).isLeft shouldBe true
+    val sip = Some("1278.0.0.1")
+    "if given no instances, should be Left" in {
+      getSSHInstance(List(), true).isLeft shouldBe true
     }
-    "with one instance given" - {
-      "should return passed argument if takeAnySingleInstance is true" in {
-        getRelevantInstance(List(instanceX), true) shouldBe Right(instanceX)
+    "Given one instance" - {
+      "Instance is ill-formed" - {
+        "If takeAnySingleInstance is true, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, None)), true).isLeft shouldBe true
+        }
+        "If takeAnySingleInstance is false, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, None)), false).isLeft shouldBe true
+        }
       }
-      "should return passed argument if takeAnySingleInstance is false" in {
-        getRelevantInstance(List(instanceX), false) shouldBe Right(instanceX)
+      "Instance is well-formed" - {
+        "If takeAnySingleInstance is true, returns argument" in {
+          getSSHInstance(List(Instance(instanceIdX, sip)), true) shouldBe Right(Instance(instanceIdX, sip))
+        }
+        "If takeAnySingleInstance is false, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, sip)), false) shouldBe Right(Instance(instanceIdX, sip))
+        }
       }
     }
-    "with two instances given" - {
-      "should select the first (in lexicographic order of InstanceId) if takeAnySingleInstance is true" in {
-        getRelevantInstance(List(instanceX, instanceY), true) shouldBe Right(instanceX)
+    "Given more than one instance" - {
+      "All instances are ill-formed" - {
+        "If takeAnySingleInstance is true, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, None)), true).isLeft shouldBe true
+        }
+        "If takeAnySingleInstance is false, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, None)), false).isLeft shouldBe true
+        }
       }
-      "should be Left if takeAnySingleInstance is false" in {
-        getRelevantInstance(List(instanceX, instanceY), false).isLeft shouldBe true
+      "At least one instance is well formed" - {
+        "If takeAnySingleInstance is true, selects the well-formed instance" in {
+          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, sip)), true) shouldBe Right(Instance(instanceIdY, sip))
+        }
+        "If takeAnySingleInstance is false, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, None), Instance(instanceIdY, sip)), false) shouldBe Right(Instance(instanceIdY, sip))
+        }
+      }
+      "All instances are well formed" - {
+        "If takeAnySingleInstance is true, selects the first well-formed instance (in lexicographic order of InstanceId)" in {
+          getSSHInstance(List(Instance(instanceIdY, sip), Instance(instanceIdX, sip)), true) shouldBe Right(Instance(instanceIdX, sip))
+        }
+        "If takeAnySingleInstance is false, should be Left" in {
+          getSSHInstance(List(Instance(instanceIdX, sip), Instance(instanceIdY, sip)), false).isLeft shouldBe true
+        }
       }
     }
   }
-
 }


### PR DESCRIPTION
This change renames `getRelevantInstance` into `getSSHInstance`, modifies its internal logic to handle the case of `Instance`s without an IP address and updates the tests.