### PR TITLE
-s/--selection newest/oldest

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,42 +34,63 @@ Run SSM in interactive/repl mode
 
 Command: ssh [options]
 Create and upload a temporary ssh key
-  -a, --any <value>        Indicates whether the command should run on any single instance
+  -s, --selection <value>  Indicates whether the command should run on any single instance
 ```
 
-The general syntax is 
+The mandatory options are: 
+
+- `--profile`, where you specify your Janus profile (for more information see [AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html)),
+
+- and either: 
+	
+	- `-i`, where you specify one or more instance ids, or 
+	- `-t`, where you specify the app name, the stack and the stage. 
+
+### Execution targets
+
+`ssm` needs to be told which 
+instances should execute the provided
+command(s). You can do this by specifying instance IDs, or by
+specifying App, Stack, and Stage tags.
 
 ```
-./ssm [cmd|repl|ssh] [options]
+# by instance ids
+	--instances i-0123456,i-9876543
+	-i i-0123456,i-9876543
+
+# by tag
+	--tags <app>,<stack>,<stage>
+	-t <app>,<stack>,<stage>
 ```
 
-An example of `cmd` is 
+If you provide tags, `ssm` will search for running instances that are
+have those tags.
+
+### Examples
+
+An example of using `cmd` is 
 
 ```
-./ssm cmd -c ls --profile security -t security-hq,security,PROD
+./ssm cmd -c date --profile security -t security-hq,security,PROD
 ```
 
-For more information about `--profile` see [AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
+where the `date` command will be ran on all matching instances.
 
-The general syntax for the `-t` switch is `-t <app>,<stack>,<stage>`. 
-
-For convenience, all subsequent examples will use the wrapper syntax.
-
-The syntax for using the `repl` command is:
+An example of using `repl` is:
 
 ```
-./ssm repl --profile <aws-profile> -t <app>,<stack>,<stage>
+./ssm repl --profile <aws-profile> -t security-hq,security,PROD
 ```
 
-This causes `ssm` to generate a list of
+The REPL mode causes `ssm` to generate a list of
 instances and then wait for commands to be specified.  Each command
 will be executed on all instances and the user can select the instance
 to display.
 
-The syntax for using the `ssh` command is:
+An example of using `ssh` command is:
 
 ```
-./ssm ssh --profile <aws-profile> -t <app>,<stack>,<stage> 
+./ssm ssh --profile <aws-profile> -t security-hq,security,PROD
 ```
 
 This causes `ssm` to generate a temporary ssh
@@ -78,64 +99,22 @@ output the command to `ssh` directly to that instance.
 The instance must already have both a public IP address _and_
 appropriate security groups.
 
-Note that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to process with one single instance with the argument `-a true`.
+Note that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to proceed with one single instance. There are three selections methods:
 
-### More usage examples
+- `-s any`, where ssm will simply selects one valid instance and runs with it.
 
-Execute a command on all matching instances:
+- `-s newest`, where ssm selects the newest of all valid instances.
 
-```
-./ssm cmd -c <command> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
-```
-
-Execute the contents of a script file on matching instances:
-
-```
-./ssm --file <path-to-script> --profile <aws-profile> --ass-tags <app>,<stack>,<stage>
-```
-
-Execute `ls` on the specified instance:
-
-```
-./ssm cmd -c ls --profile <aws-profile> --instances i-01234567
-```
-
-Execute `ls` on multiple specified instances (using the short form of
-the arguments):
-
-```
-./ssm cmd -f <path-to-script> --profile <aws-profile> -i i-01234567,i-98765432
-```
-
-### Execution targets
-
-As seen in the previous section, `ssm` needs to be told which 
-instances should execute the provided
-command(s). You can do this by specifying instance IDs, or by
-specifying App, Stack, and Stage tags.
-
-```
-# by ID
-... --instances i-0123456,i-9876543
-... -i i-0123456,i-9876543
-
-# by tag
-... --asset-tags <app>,<stack>,<stage>
-... -t <app>,<stack>,<stage>
-```
-
-If you provide tags, `ssm` will search for running instances that are
-have those tags.
-
+- `-s oldest`, where ssm selects the oldest of all valid instances. 
 
 ## Development
 
 During development, the program can be run using sbt, either from an
 sbt shell or from the CLI in that project.
 
-    $ sbt "run --instances i-0123456 --profile xxx --region xxx --cmd pwd"
+    $ sbt "run --c pwd --instances i-0123456 --profile xxx --region xxx"
 
-    sbt:ssm-scala> run --instances i-0123456 --profile xxx --region xxx --cmd pwd
+    sbt:ssm-scala> run --c pwd --instances i-0123456 --profile xxx --region xxx 
 
 However, `sbt` traps the program exit so in REPL mode you may find it
 easier to create and run an executable instead, for this just run 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ Run SSM in interactive/repl mode
 
 Command: ssh [options]
 Create and upload a temporary ssh key
-  -s, --selection <value>  Indicates whether the command should run on any single instance
+  -s, --selection <value>  
+    Indicates that in the case of multiple valid instances one
+    should be chosen to proceed and indicates which method to
+    use. With 'any' selects any instance; with 'newest' selects
+    the newest valid instance and with 'oldest' selects the
+    oldest valid instance.
 ```
 
 The mandatory options are: 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -66,9 +66,9 @@ object ArgumentParser {
       .action((_, c) => c.copy(mode = Some(SsmSsh)))
       .text("Create and upload a temporary ssh key")
       .children(
-        opt[Boolean]('a', "any").optional()
-          .action((flag, args) => args.copy(takeAnySingleInstance = Some(flag)))
-          .text("Indicates whether the command should run on any single instance"),
+        opt[String]('s', "selection").optional()
+          .action((selectionMode, args) => args.copy(singleInstanceSelectionMode = Some(selectionMode)))
+          .text("Indicates whether the command should run on any single instance")
       )
 
     checkConfig { args =>

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -68,7 +68,12 @@ object ArgumentParser {
       .children(
         opt[String]('s', "selection").optional()
           .action((selectionMode, args) => args.copy(singleInstanceSelectionMode = Some(selectionMode)))
-          .text("Indicates whether the command should run on any single instance")
+          .text("""
+                  |    Indicates that in the case of multiple valid instances one
+                  |    should be chosen to proceed and indicates which method to
+                  |    use. With 'any' selects any instance; with 'newest' selects
+                  |    the newest valid instance and with 'oldest' selects the
+                  |    oldest valid instance.""".stripMargin)
       )
 
     checkConfig { args =>

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -33,7 +33,7 @@ object Logic {
     case _ => Right(Unit)
   }
 
-  def getSSHInstance(instances: List[Instance], takeAnySingleInstance: Boolean): Either[FailedAttempt, Instance] = {
+  def getSSHInstance(instances: List[Instance], singleInstanceSelectionModeOpt: Option[String]): Either[FailedAttempt, Instance] = {
     val sortedValidInstances = instances
       .filter(_.publicIpAddressOpt.isDefined)
       .sortBy(_.id.id)
@@ -45,7 +45,7 @@ object Logic {
           Left(FailedAttempt(Failure(s"Instances with no IPs", s"Found ${instances.map(_.id.id).mkString(", ")} but none are valid targets (instances need public IP addresses)", UnhandledError, None, None)))
         case instance :: Nil =>
           Right(instance)
-        case instance :: _ if takeAnySingleInstance =>
+        case instance :: _ if singleInstanceSelectionModeOpt.getOrElse("") == "any" =>
           Right(instance)
         case _ :: _ :: _ =>
           Left(FailedAttempt(Failure(s"Unable to identify a single instance", s"Error choosing single instance, found ${sortedValidInstances.map(_.id.id).mkString(", ")}", UnhandledError, None, None)))

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -7,13 +7,15 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 import com.gu.ssm.ArgumentParser.argParser
 
+import com.gu.ssm.Logic._
+
 object Main {
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
   private val maximumWaitTime = 25.seconds
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, Some(profile), region, Some(mode), singleInstanceSelectionModeOpt)) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, Some(profile), region, Some(mode), sismOpt)) =>
         val awsClients = Logic.getClients(profile, region)
         mode match {
           case SsmRepl =>
@@ -24,7 +26,7 @@ object Main {
               case _ => fail()
             }
           case SsmSsh =>
-            setUpSSH(awsClients, profile, region, executionTarget, singleInstanceSelectionModeOpt)
+            setUpSSH(awsClients, profile, region, executionTarget, sismOpt)
         }
       case Some(_) => fail()
       case None => System.exit(ArgumentsError.code) // parsing cmd line args failed, help message will have been displayed
@@ -36,13 +38,13 @@ object Main {
     System.exit(UnhandledError.code)
   }
 
-  private def setUpSSH(awsClients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget, singleInstanceSelectionModeOpt: Option[String]): Unit = {
+  private def setUpSSH(awsClients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget, sism: SingleInstanceSelectionMode): Unit = {
     val fProgramResult = for {
       config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, profile, region, executionTarget)
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (authFile, authKey) = sshArtifacts
       addAndRemoveKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addKeyCommand(authKey) + SSH.removeKeyCommand(authKey)
-      instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, singleInstanceSelectionModeOpt))
+      instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, sism))
       _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
       _ <- IO.installSshKey(instance.id, config.name, addAndRemoveKeyCommand, awsClients.ssmClient)
     } yield SSH.sshCmd(authFile, instance)

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -13,7 +13,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, Some(profile), region, Some(mode), Some(takeAnySingleInstance))) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, Some(profile), region, Some(mode), singleInstanceSelectionModeOpt)) =>
         val awsClients = Logic.getClients(profile, region)
         mode match {
           case SsmRepl =>
@@ -24,7 +24,7 @@ object Main {
               case _ => fail()
             }
           case SsmSsh =>
-            setUpSSH(awsClients, profile, region, executionTarget, takeAnySingleInstance)
+            setUpSSH(awsClients, profile, region, executionTarget, singleInstanceSelectionModeOpt)
         }
       case Some(_) => fail()
       case None => System.exit(ArgumentsError.code) // parsing cmd line args failed, help message will have been displayed
@@ -36,13 +36,13 @@ object Main {
     System.exit(UnhandledError.code)
   }
 
-  private def setUpSSH(awsClients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget, takeAnySingleInstance: Boolean): Unit = {
+  private def setUpSSH(awsClients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget, singleInstanceSelectionModeOpt: Option[String]): Unit = {
     val fProgramResult = for {
       config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, profile, region, executionTarget)
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (authFile, authKey) = sshArtifacts
       addAndRemoveKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addKeyCommand(authKey) + SSH.removeKeyCommand(authKey)
-      instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, takeAnySingleInstance))
+      instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, singleInstanceSelectionModeOpt))
       _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
       _ <- IO.installSshKey(instance.id, config.name, addAndRemoveKeyCommand, awsClients.ssmClient)
     } yield SSH.sshCmd(authFile, instance)

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -45,7 +45,8 @@ object EC2 {
       reservation <- describeInstancesResult.getReservations.asScala
       awsInstance <- reservation.getInstances.asScala
       instanceId = awsInstance.getInstanceId
-    } yield Instance(InstanceId(instanceId), Option(awsInstance.getPublicIpAddress))).toList
+      launchDateTime = awsInstance.getLaunchTime
+    } yield Instance(InstanceId(instanceId), Option(awsInstance.getPublicIpAddress), launchDateTime)).toList
   }
 
   def tagInstance(id: InstanceId, key: String, value: String, client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] = {

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -5,10 +5,11 @@ import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsync
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
 import com.gu.ssm.aws.SSM
+import java.util.Date
 
 
 case class InstanceId(id: String) extends AnyVal
-case class Instance(id: InstanceId, publicIpAddressOpt: Option[String])
+case class Instance(id: InstanceId, publicIpAddressOpt: Option[String], launchDateTime: Date)
 case class AppStackStage(app: String, stack: String, stage: String)
 case class ExecutionTarget(instances: Option[List[InstanceId]] = None, ass: Option[AppStackStage] = None)
 

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -4,7 +4,6 @@ import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsync
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
-import com.gu.ssm.aws.SSM
 import java.util.Date
 
 
@@ -13,9 +12,9 @@ case class Instance(id: InstanceId, publicIpAddressOpt: Option[String], launchDa
 case class AppStackStage(app: String, stack: String, stage: String)
 case class ExecutionTarget(instances: Option[List[InstanceId]] = None, ass: Option[AppStackStage] = None)
 
-case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[String], profile: Option[String], region: Region, mode: Option[SsmMode], takeAnySingleInstance: Option[Boolean])
+case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[String], profile: Option[String], region: Region, mode: Option[SsmMode], singleInstanceSelectionMode: Option[String])
 object Arguments {
-  def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), None, Some(false))
+  def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), None, None)
 }
 
 sealed trait CommandStatus

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -48,3 +48,9 @@ case class AWSClients (
 )
 
 case class ResultsWithInstancesNotFound(results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])], instancesNotFound: List[InstanceId])
+
+sealed trait SingleInstanceSelectionMode
+case object SismAny extends SingleInstanceSelectionMode
+case object SismNewest extends SingleInstanceSelectionMode
+case object SismOldest extends SingleInstanceSelectionMode
+case object SismUnspecified extends SingleInstanceSelectionMode

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -59,33 +59,33 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     val instanceYWithIP = Instance(instanceIdY, sip, dateNew)
 
     "if given no instances, should be Left" in {
-      getSSHInstance(List(), None).isLeft shouldBe true
+      getSSHInstance(List(), SismUnspecified).isLeft shouldBe true
     }
 
     "Given one instance" - {
 
       "Instance is ill-formed should be Left" in {
         val oneInstanceWithoutIP = List(instanceXWithoutIP)
-        getSSHInstance(oneInstanceWithoutIP, None).isLeft shouldBe true
+        getSSHInstance(oneInstanceWithoutIP,  SismUnspecified).isLeft shouldBe true
       }
 
       "Instance is well-formed, should return argument in all cases" - {
         val oneInstanceWithIP = List(instanceXWithIP)
 
-        "If singleInstanceSelectionModeOpt is None, returns argument" in {
-          getSSHInstance(oneInstanceWithIP, None).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is None, returns argument" in {
+          getSSHInstance(oneInstanceWithIP,  SismUnspecified).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"any\"), returns argument" in {
-          getSSHInstance(oneInstanceWithIP, Some("any")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismAny, returns argument" in {
+          getSSHInstance(oneInstanceWithIP, SismAny).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"newest\"), returns argument" in {
-          getSSHInstance(oneInstanceWithIP, Some("newest")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismNewest, returns argument" in {
+          getSSHInstance(oneInstanceWithIP, SismNewest).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"oldest\"), returns argument" in {
-          getSSHInstance(oneInstanceWithIP, Some("oldest")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismOldest, returns argument" in {
+          getSSHInstance(oneInstanceWithIP, SismOldest).right.get shouldEqual instanceXWithIP
         }
       }
     }
@@ -95,47 +95,47 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
       "All instances are ill-formed" - {
         val twoInstancesWithoutIP = List(instanceYWithoutIP, instanceXWithoutIP)
         "should be Left" in {
-          getSSHInstance(twoInstancesWithoutIP, None).isLeft shouldBe true
+          getSSHInstance(twoInstancesWithoutIP, SismUnspecified).isLeft shouldBe true
         }
       }
 
       "At least one instance is well formed" - {
         val twoMixedInstances = List(instanceYWithoutIP, instanceXWithIP)
 
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(twoMixedInstances, None).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismUnspecified), should be Left" in {
+          getSSHInstance(twoMixedInstances, SismUnspecified).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"any\"), selects the well-formed instance" in {
-          getSSHInstance(twoMixedInstances, Some("any")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismAny, selects the well-formed instance" in {
+          getSSHInstance(twoMixedInstances, SismAny).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"newest\"), selects the well-formed instance" in {
-          getSSHInstance(twoMixedInstances, Some("newest")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismNewest, selects the well-formed instance" in {
+          getSSHInstance(twoMixedInstances, SismNewest).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"oldest\"), selects the well-formed instance" in {
-          getSSHInstance(twoMixedInstances, Some("oldest")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismOldest, selects the well-formed instance" in {
+          getSSHInstance(twoMixedInstances, SismOldest).right.get shouldEqual instanceXWithIP
         }
       }
 
       "All instances are well formed" - {
         val twoInstancesWithIP = List(instanceYWithIP, instanceXWithIP)
 
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(twoInstancesWithIP, None).isLeft shouldBe true
+        "If single instance selection mode is SismUnspecified, should be Left" in {
+          getSSHInstance(twoInstancesWithIP, SismUnspecified).isLeft shouldBe true
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"any\"), selects the first well-formed instance (in lexicographic order of InstanceId)" in {
-          getSSHInstance(twoInstancesWithIP, Some("any")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismAny, selects the first well-formed instance (in lexicographic order of InstanceId)" in {
+          getSSHInstance(twoInstancesWithIP, SismAny).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"newest\"), selects the instance with the most recent launch DateTime" in {
-          getSSHInstance(twoInstancesWithIP, Some("newest")).right.get shouldEqual instanceYWithIP
+        "If single instance selection mode is SismNewest, selects the instance with the most recent launch DateTime" in {
+          getSSHInstance(twoInstancesWithIP, SismNewest).right.get shouldEqual instanceYWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is Some(\"oldest\"), selects the instance with the oldest launch DateTime" in {
-          getSSHInstance(twoInstancesWithIP, Some("oldest")).right.get shouldEqual instanceXWithIP
+        "If single instance selection mode is SismOldest, selects the instance with the oldest launch DateTime" in {
+          getSSHInstance(twoInstancesWithIP, SismOldest).right.get shouldEqual instanceXWithIP
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -52,7 +52,7 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     val instanceYWithIP = Instance(instanceIdY, Some("1278.0.0.1"), new Date())
 
     "if given no instances, should be Left" in {
-      getSSHInstance(List(), true).isLeft shouldBe true
+      getSSHInstance(List(), Some("any")).isLeft shouldBe true
     }
 
     "Given one instance" - {
@@ -60,24 +60,24 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
       "Instance is ill-formed" - {
         val oneInstanceWithoutIP = List(instanceXWithoutIP)
 
-        "If takeAnySingleInstance is true, should be Left" in {
-          getSSHInstance(oneInstanceWithoutIP, true).isLeft shouldBe true
+        "If singleInstanceSelectionModeOpt is Some(\"any\"), should be Left" in {
+          getSSHInstance(oneInstanceWithoutIP, Some("any")).isLeft shouldBe true
         }
 
-        "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(oneInstanceWithoutIP, false).isLeft shouldBe true
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(oneInstanceWithoutIP, None).isLeft shouldBe true
         }
       }
 
       "Instance is well-formed" - {
         val oneInstanceWithIP = List(instanceXWithIP)
 
-        "If takeAnySingleInstance is true, returns argument" in {
-          getSSHInstance(oneInstanceWithIP, true).right.get shouldEqual instanceXWithIP
+        "IfsingleInstanceSelectionModeOpt is Some(\"any\"), returns argument" in {
+          getSSHInstance(oneInstanceWithIP, Some("any")).right.get shouldEqual instanceXWithIP
         }
 
-        "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(oneInstanceWithIP, false).right.get shouldEqual instanceXWithIP
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(oneInstanceWithIP, None).right.get shouldEqual instanceXWithIP
         }
       }
     }
@@ -87,36 +87,36 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
       "All instances are ill-formed" - {
         val twoInstancesWithIP = List(instanceYWithoutIP, instanceXWithoutIP)
 
-        "If takeAnySingleInstance is true, should be Left" in {
-          getSSHInstance(twoInstancesWithIP, true).isLeft shouldBe true
+        "If singleInstanceSelectionModeOpt is Some(\"any\"), should be Left" in {
+          getSSHInstance(twoInstancesWithIP, Some("any")).isLeft shouldBe true
         }
 
-        "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(twoInstancesWithIP, false).isLeft shouldBe true
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(twoInstancesWithIP, None).isLeft shouldBe true
         }
       }
 
       "At least one instance is well formed" - {
         val twoMixedInstances = List(instanceYWithoutIP, instanceXWithIP)
 
-        "If takeAnySingleInstance is true, selects the well-formed instance" in {
-          getSSHInstance(twoMixedInstances, true).right.get shouldEqual instanceXWithIP
+        "If singleInstanceSelectionModeOpt is Some(\"any\"), selects the well-formed instance" in {
+          getSSHInstance(twoMixedInstances, Some("any")).right.get shouldEqual instanceXWithIP
         }
 
-        "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(twoMixedInstances, false).right.get shouldEqual instanceXWithIP
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(twoMixedInstances, None).right.get shouldEqual instanceXWithIP
         }
       }
 
       "All instances are well formed" - {
         val twoInstancesWithIP = List(instanceYWithIP, instanceXWithIP)
 
-        "If takeAnySingleInstance is true, selects the first well-formed instance (in lexicographic order of InstanceId)" in {
-          getSSHInstance(twoInstancesWithIP, true).right.get shouldEqual instanceXWithIP
+        "If singleInstanceSelectionModeOpt is Some(\"any\"), selects the first well-formed instance (in lexicographic order of InstanceId)" in {
+          getSSHInstance(twoInstancesWithIP, Some("any")).right.get shouldEqual instanceXWithIP
         }
 
-        "If takeAnySingleInstance is false, should be Left" in {
-          getSSHInstance(twoInstancesWithIP, false).isLeft shouldBe true
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(twoInstancesWithIP, None).isLeft shouldBe true
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -72,7 +72,7 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
       "Instance is well-formed, should return argument in all cases" - {
         val oneInstanceWithIP = List(instanceXWithIP)
 
-        "If single instance selection mode is None, returns argument" in {
+        "If single instance selection mode is SismUnspecified, returns argument" in {
           getSSHInstance(oneInstanceWithIP,  SismUnspecified).right.get shouldEqual instanceXWithIP
         }
 
@@ -94,6 +94,7 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
 
       "All instances are ill-formed" - {
         val twoInstancesWithoutIP = List(instanceYWithoutIP, instanceXWithoutIP)
+
         "should be Left" in {
           getSSHInstance(twoInstancesWithoutIP, SismUnspecified).isLeft shouldBe true
         }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -43,41 +43,49 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
 
   "getRelevantInstance" - {
     import Logic.getSSHInstance
-    import java.util.Date
+    import java.text.SimpleDateFormat
+
+    val sip = Some("1278.0.0.1")
+
+    val formatter = new SimpleDateFormat("yyyy-MM-d HH:mm:ss")
+    val dateOld = formatter.parse("2018-02-17 13:00:14")
+    val dateNew = formatter.parse("2018-02-17 15:05:22")
+
     val instanceIdX = InstanceId("X")
     val instanceIdY = InstanceId("Y")
-    val instanceXWithoutIP = Instance(instanceIdX, None, new Date())
-    val instanceYWithoutIP = Instance(instanceIdY, None, new Date())
-    val instanceXWithIP = Instance(instanceIdX, Some("1278.0.0.1"), new Date())
-    val instanceYWithIP = Instance(instanceIdY, Some("1278.0.0.1"), new Date())
+    val instanceXWithoutIP = Instance(instanceIdX, None, dateOld)
+    val instanceYWithoutIP = Instance(instanceIdY, None, dateNew)
+    val instanceXWithIP = Instance(instanceIdX, sip, dateOld)
+    val instanceYWithIP = Instance(instanceIdY, sip, dateNew)
 
     "if given no instances, should be Left" in {
-      getSSHInstance(List(), Some("any")).isLeft shouldBe true
+      getSSHInstance(List(), None).isLeft shouldBe true
     }
 
     "Given one instance" - {
 
-      "Instance is ill-formed" - {
+      "Instance is ill-formed should be Left" in {
         val oneInstanceWithoutIP = List(instanceXWithoutIP)
-
-        "If singleInstanceSelectionModeOpt is Some(\"any\"), should be Left" in {
-          getSSHInstance(oneInstanceWithoutIP, Some("any")).isLeft shouldBe true
-        }
-
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(oneInstanceWithoutIP, None).isLeft shouldBe true
-        }
+        getSSHInstance(oneInstanceWithoutIP, None).isLeft shouldBe true
       }
 
-      "Instance is well-formed" - {
+      "Instance is well-formed, should return argument in all cases" - {
         val oneInstanceWithIP = List(instanceXWithIP)
 
-        "IfsingleInstanceSelectionModeOpt is Some(\"any\"), returns argument" in {
+        "If singleInstanceSelectionModeOpt is None, returns argument" in {
+          getSSHInstance(oneInstanceWithIP, None).right.get shouldEqual instanceXWithIP
+        }
+
+        "If singleInstanceSelectionModeOpt is Some(\"any\"), returns argument" in {
           getSSHInstance(oneInstanceWithIP, Some("any")).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(oneInstanceWithIP, None).right.get shouldEqual instanceXWithIP
+        "If singleInstanceSelectionModeOpt is Some(\"newest\"), returns argument" in {
+          getSSHInstance(oneInstanceWithIP, Some("newest")).right.get shouldEqual instanceXWithIP
+        }
+
+        "If singleInstanceSelectionModeOpt is Some(\"oldest\"), returns argument" in {
+          getSSHInstance(oneInstanceWithIP, Some("oldest")).right.get shouldEqual instanceXWithIP
         }
       }
     }
@@ -85,38 +93,49 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     "Given more than one instance" - {
 
       "All instances are ill-formed" - {
-        val twoInstancesWithIP = List(instanceYWithoutIP, instanceXWithoutIP)
-
-        "If singleInstanceSelectionModeOpt is Some(\"any\"), should be Left" in {
-          getSSHInstance(twoInstancesWithIP, Some("any")).isLeft shouldBe true
-        }
-
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(twoInstancesWithIP, None).isLeft shouldBe true
+        val twoInstancesWithoutIP = List(instanceYWithoutIP, instanceXWithoutIP)
+        "should be Left" in {
+          getSSHInstance(twoInstancesWithoutIP, None).isLeft shouldBe true
         }
       }
 
       "At least one instance is well formed" - {
         val twoMixedInstances = List(instanceYWithoutIP, instanceXWithIP)
 
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(twoMixedInstances, None).right.get shouldEqual instanceXWithIP
+        }
+
         "If singleInstanceSelectionModeOpt is Some(\"any\"), selects the well-formed instance" in {
           getSSHInstance(twoMixedInstances, Some("any")).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(twoMixedInstances, None).right.get shouldEqual instanceXWithIP
+        "If singleInstanceSelectionModeOpt is Some(\"newest\"), selects the well-formed instance" in {
+          getSSHInstance(twoMixedInstances, Some("newest")).right.get shouldEqual instanceXWithIP
+        }
+
+        "If singleInstanceSelectionModeOpt is Some(\"oldest\"), selects the well-formed instance" in {
+          getSSHInstance(twoMixedInstances, Some("oldest")).right.get shouldEqual instanceXWithIP
         }
       }
 
       "All instances are well formed" - {
         val twoInstancesWithIP = List(instanceYWithIP, instanceXWithIP)
 
+        "If singleInstanceSelectionModeOpt is None, should be Left" in {
+          getSSHInstance(twoInstancesWithIP, None).isLeft shouldBe true
+        }
+
         "If singleInstanceSelectionModeOpt is Some(\"any\"), selects the first well-formed instance (in lexicographic order of InstanceId)" in {
           getSSHInstance(twoInstancesWithIP, Some("any")).right.get shouldEqual instanceXWithIP
         }
 
-        "If singleInstanceSelectionModeOpt is None, should be Left" in {
-          getSSHInstance(twoInstancesWithIP, None).isLeft shouldBe true
+        "If singleInstanceSelectionModeOpt is Some(\"newest\"), selects the instance with the most recent launch DateTime" in {
+          getSSHInstance(twoInstancesWithIP, Some("newest")).right.get shouldEqual instanceYWithIP
+        }
+
+        "If singleInstanceSelectionModeOpt is Some(\"oldest\"), selects the instance with the oldest launch DateTime" in {
+          getSSHInstance(twoInstancesWithIP, Some("oldest")).right.get shouldEqual instanceXWithIP
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -43,12 +43,13 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
 
   "getRelevantInstance" - {
     import Logic.getSSHInstance
+    import java.util.Date
     val instanceIdX = InstanceId("X")
     val instanceIdY = InstanceId("Y")
-    val instanceXWithoutIP = Instance(instanceIdX, None)
-    val instanceYWithoutIP = Instance(instanceIdY, None)
-    val instanceXWithIP = Instance(instanceIdX, Some("1278.0.0.1"))
-    val instanceYWithIP = Instance(instanceIdY, Some("1278.0.0.1"))
+    val instanceXWithoutIP = Instance(instanceIdX, None, new Date())
+    val instanceYWithoutIP = Instance(instanceIdY, None, new Date())
+    val instanceXWithIP = Instance(instanceIdX, Some("1278.0.0.1"), new Date())
+    val instanceYWithIP = Instance(instanceIdY, Some("1278.0.0.1"), new Date())
 
     "if given no instances, should be Left" in {
       getSSHInstance(List(), true).isLeft shouldBe true

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -50,10 +50,11 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
   "create ssh command" - {
     import SSH.sshCmd
+    import java.util.Date
 
     "create ssh command" in {
       val file: File = new File("/banana")
-      val instance: Instance = Instance(InstanceId("raspberry"), Some("127.0.0.1"))
+      val instance: Instance = Instance(InstanceId("raspberry"), Some("127.0.0.1"), new Date())
       val cmd = sshCmd(file, instance)
       cmd._1.id shouldEqual "raspberry"
       cmd._2 should include ("ssh -i /banana ubuntu@127.0.0.1")


### PR DESCRIPTION

In this commit:

1. We update the definition of an instance to `Instance(id: InstanceId, publicIpAddressOpt: Option[String], launchDateTime: Date)`, thereby adding the instance's Launch DateTime.

2. We are moving from `-a/--any <boolean>` to `-s/--selection <selectionMode>`, where selection mode take values in `["any","oldest","newest"]`. This means that we now have one command line option controlling which instance is selected if more than one instances were found in the case of the `ssh` sub command.

3. The README has been updated to remove some obsolete information, be more simple/useful and to be up to date with the `-s/--selection` switch.
