### PR TITLE
Instant.now()

### DIFF
--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -2,7 +2,7 @@ package com.gu.ssm
 
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
 import java.io.File
-import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.time.Instant
 
 class SSHTest extends FreeSpec with Matchers with EitherValues {
 
@@ -53,7 +53,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
     "create ssh command" in {
       val file = new File("/banana")
-      val instance = Instance(InstanceId("raspberry"), Some("127.0.0.1"), LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant())
+      val instance = Instance(InstanceId("raspberry"), Some("127.0.0.1"), Instant.now())
       val cmd = sshCmd(file, instance)
       cmd._1.id shouldEqual "raspberry"
       cmd._2 should include ("ssh -i /banana ubuntu@127.0.0.1")


### PR DESCRIPTION
@adam

Follow up of the office discussion about:

```
LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()
```

java.util.Date doesn't have a time zone attached to it. In fact AWS is not making any choice of a "default time zone" when they return it in their SDK, because java.util.Date is essentially just a Long.

The problem we have is "create an Instant", not "create a datetime in UTC time zone".

So now that we don't have to worry about timezones, what is the most perfect way to create an Instant ?

This change does it perfectly (^_^)