### PR TITLE
Introduce InvocationDoesNotExist and handle AWS error

### DIFF
--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -39,7 +39,11 @@ object SSM {
     val request = new GetCommandInvocationRequest()
       .withCommandId(commandId)
       .withInstanceId(instance.id)
-    handleAWSErrs(awsToScala(client.getCommandInvocationAsync)(request).map(extractCommandResult))
+    handleAWSErrs(
+      awsToScala(client.getCommandInvocationAsync)(request)
+        .map(extractCommandResult)
+        .recover { case e if e.getMessage.contains("InvocationDoesNotExist") => Left(InvocationDoesNotExist) }
+    )
   }
 
   def extractCommandResult(getCommandInvocationResult: GetCommandInvocationResult): Either[CommandStatus, CommandResult] = {

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -59,7 +59,6 @@ object SSM {
 
   def getCmdOutput(instance: InstanceId, commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[(InstanceId, Either[CommandStatus, CommandResult])] = {
     for {
-      _ <- Attempt.delay(500.millis)
       cmdResult <- Attempt.retryUntil(30, 500.millis, () => getCommandInvocation(instance, commandId, client))(_.isRight)
     } yield instance -> cmdResult
   }

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -27,6 +27,7 @@ case object Failed extends CommandStatus
 case object Canceled extends CommandStatus
 case object Undeliverable extends CommandStatus
 case object Terminated extends CommandStatus
+case object InvocationDoesNotExist extends CommandStatus
 
 sealed trait SsmMode
 case object SsmCmd extends SsmMode


### PR DESCRIPTION
We were finding the following error when running a command against all instances of our elasticsearch cluster:

```
$  ~ ./ssm cmd -c 'date' --profile ophan -t elasticsearch,ophan,PROD
SLF4J: A number (14) of logging calls during the initialization phase have been intercepted and are
SLF4J: now being replayed. These are subject to the filtering rules of the underlying logging system.
SLF4J: See also http://www.slf4j.org/codes.html#replay
Unknown error while making an API call to AWS' AWSSimpleSystemsManagement service, null (Service: AWSSimpleSystemsManagement; Status Code: 400; Error Code: InvocationDoesNotExist; Request ID: d46022a8-188f-11e8-9548-511ec617bfed)
```
We fix this by capturing this particular error from AWS as a new `CommandStatus`: `InvocationDoesNotExist`.

We have tested this change locally and can confirm we no longer receive the error. 
@rtyley 


