### PR TITLE
[PoC] Add `emr-cluster` flag to support running commands on EMR master nodes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-emr" % awsSdkVersion,
   "com.github.scopt" %% "scopt" % "3.7.0",
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
   "ch.qos.logback" %  "logback-classic" % "1.1.7",

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -3,6 +3,7 @@ package com.gu.ssm
 import java.io.File
 
 import com.amazonaws.regions.{Region, Regions}
+import com.gu.ssm.model.{AppStackStage, EMRClusterId, InstanceId, InstanceIds}
 import scopt.OptionParser
 
 
@@ -18,8 +19,13 @@ object ArgumentParser {
     opt[Seq[String]]('i', "instances")
       .action { (instanceIds, args) =>
         val instances = instanceIds.map(i => InstanceId(i)).toList
-        args.copy(executionTarget = Some(ExecutionTarget(instances = Some(instances))))
+        args.copy(executionTarget = Some(InstanceIds(instances)))
       } text "Specify the instance ID(s) on which the specified command(s) should execute"
+
+    opt[String]("cluster-id")
+      .action { (clusterId, args) =>
+        args.copy(executionTarget = Some(EMRClusterId(clusterId)))
+      } text "An EMR cluster ID – the command will be executed on its master node"
 
     opt[String]('t', "tags")
       .validate { tagsStr =>
@@ -29,7 +35,7 @@ object ArgumentParser {
         Logic.extractSASTags(tagsStr)
           .fold(
             _ => args,
-            ass => args.copy(executionTarget = Some(ExecutionTarget(ass = Some(ass))))
+            ass => args.copy(executionTarget = Some(ass))
           )
       } text "Search for instances by tag e.g. '--tags app,stack,stage'"
 

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -2,23 +2,37 @@ package com.gu.ssm
 
 import com.amazonaws.regions.Region
 import com.amazonaws.services.ec2.AmazonEC2Async
+import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduceAsync
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsync
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
-import com.gu.ssm.aws.{EC2, SSM, STS}
+import com.gu.ssm.aws.{EC2, EMR, SSM, STS}
+import com.gu.ssm.model._
 import com.gu.ssm.utils.attempt.{ArgumentsError, Attempt, Failure}
 
 import scala.concurrent.ExecutionContext
 
 
 object IO {
-  def resolveInstances(executionTarget: ExecutionTarget, ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
-    executionTarget.instances.map( instances =>
-      EC2.resolveInstanceIds(instances, ec2Client)
-    ).orElse {
-      executionTarget.ass.map { ass =>
+
+  def resolveInstances(
+    executionTarget: ExecutionTarget,
+    ec2Client: AmazonEC2Async,
+    emrClient: AmazonElasticMapReduceAsync
+  )(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
+
+    executionTarget match {
+      case InstanceIds(ids) =>
+        EC2.resolveInstanceIds(ids, ec2Client)
+
+      case ass: AppStackStage =>
         EC2.resolveASSInstances(ass, ec2Client)
-      }
-    }.getOrElse(Attempt.Left(Failure("Unable to resolve execution target", "You must provide an execution target (instance(s) or tags)", ArgumentsError)))
+
+      case EMRClusterId(id) =>
+        new EMR(emrClient).resolveMasterInstances(id)
+
+      case _ =>
+        Attempt.Left(Failure("Unable to resolve execution target", "You must provide an execution target (instance(s), tags or EMR cluster ID)", ArgumentsError))
+    }
   }
 
   def executeOnInstances(instanceIds: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
@@ -37,10 +51,10 @@ object IO {
   def tagAsTainted(instanceId: InstanceId, username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
     EC2.tagInstance(instanceId, "taintedBy", username, ec2Client)
 
-  def getSSMConfig(ec2Client: AmazonEC2Async, stsClient: AWSSecurityTokenServiceAsync, profile: String, region: Region, executionTarget: ExecutionTarget)(implicit ec: ExecutionContext): Attempt[SSMConfig] = {
+  def getSSMConfig(clients: AWSClients, profile: String, region: Region, executionTarget: ExecutionTarget)(implicit ec: ExecutionContext): Attempt[SSMConfig] = {
     for {
-      instances <- IO.resolveInstances(executionTarget, ec2Client)
-      name <- STS.getCallerIdentity(stsClient)
+      instances <- IO.resolveInstances(executionTarget, clients.ec2, clients.emr)
+      name <- STS.getCallerIdentity(clients.sts)
     } yield SSMConfig(instances, name)
   }
 }

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -4,9 +4,11 @@ import java.io.File
 
 import com.amazonaws.regions.Region
 import com.amazonaws.services.ec2.AmazonEC2Async
+import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduceAsync
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsync
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
-import com.gu.ssm.aws.{EC2, SSM, STS}
+import com.gu.ssm.aws.{EC2, EMR, SSM, STS}
+import com.gu.ssm.model._
 import com.gu.ssm.utils.attempt.{ErrorCode, FailedAttempt, Failure, UnhandledError}
 
 import scala.io.Source
@@ -54,10 +56,18 @@ object Logic {
     val ssmClient: AWSSimpleSystemsManagementAsync = SSM.client(profile, region)
     val stsClient: AWSSecurityTokenServiceAsync = STS.client(profile, region)
     val ec2Client: AmazonEC2Async = EC2.client(profile, region)
-    AWSClients(ssmClient, stsClient, ec2Client)
+    val emrClient: AmazonElasticMapReduceAsync = EMR.client(profile, region)
+
+    AWSClients(ssmClient, stsClient, ec2Client, emrClient)
   }
 
-  def computeIncorrectInstances(executionTarget: ExecutionTarget, instanceIds: List[InstanceId]): List[InstanceId] =
-    executionTarget.instances.getOrElse(List()).filterNot(instanceIds.toSet)
+  def computeIncorrectInstances(executionTarget: ExecutionTarget, instanceIds: List[InstanceId]): List[InstanceId] = {
+    executionTarget match {
+      case InstanceIds(ids) =>
+        ids.filterNot(instanceIds.toSet)
 
+      case _ =>
+        Nil
+    }
+  }
 }

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -4,8 +4,9 @@ import java.io.{File, IOException}
 import java.security.{NoSuchAlgorithmException, NoSuchProviderException}
 import java.util.Calendar
 
+import com.gu.ssm.model.{Instance, InstanceId}
 import com.gu.ssm.utils.attempt._
-import com.gu.ssm.utils.{KeyMaker, FilePermissions}
+import com.gu.ssm.utils.{FilePermissions, KeyMaker}
 
 object SSH {
 

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -1,5 +1,6 @@
 package com.gu.ssm
 
+import com.gu.ssm.model.InstanceId
 import com.gu.ssm.utils.attempt.FailedAttempt
 
 

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -5,14 +5,15 @@ import com.amazonaws.regions.Region
 import com.amazonaws.services.ec2.model._
 import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.gu.ssm.model.{AppStackStage, Instance, InstanceId}
 import com.gu.ssm.utils.attempt.Attempt
-import com.gu.ssm.{AppStackStage, Instance, InstanceId}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 
 object EC2 {
+
   def client(profileName: String, region: Region): AmazonEC2Async = {
     AmazonEC2AsyncClientBuilder.standard()
       .withCredentials(new ProfileCredentialsProvider(profileName))

--- a/src/main/scala/com/gu/ssm/aws/EMR.scala
+++ b/src/main/scala/com/gu/ssm/aws/EMR.scala
@@ -1,0 +1,50 @@
+package com.gu.ssm.aws
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.services.elasticmapreduce.model._
+import com.amazonaws.services.elasticmapreduce.{AmazonElasticMapReduceAsync, AmazonElasticMapReduceAsyncClientBuilder}
+import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.gu.ssm.model.{Instance, InstanceId}
+import com.gu.ssm.utils.attempt.Attempt
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+class EMR(client: AmazonElasticMapReduceAsync) {
+
+  def resolveMasterInstances(clusterId: String)(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
+    val describeClusterReq = new DescribeClusterRequest()
+      .withClusterId(clusterId)
+
+    val listInstancesReq = new ListInstancesRequest()
+      .withClusterId(clusterId)
+      .withInstanceStates(InstanceState.RUNNING)
+      .withInstanceGroupTypes(InstanceGroupType.MASTER)
+
+    for {
+      cluster <- handleAWSErrs(awsToScala(client.describeClusterAsync)(describeClusterReq))
+      instances <- handleAWSErrs(awsToScala(client.listInstancesAsync)(listInstancesReq))
+    } yield extractInstances(cluster, instances)
+  }
+
+  private def extractInstances(cluster: DescribeClusterResult, instances: ListInstancesResult): List[Instance] = {
+    instances.getInstances.asScala.toList.map { awsInstance =>
+      Instance(
+        InstanceId(awsInstance.getId),
+        Option(awsInstance.getPublicIpAddress),
+        cluster.getCluster.getStatus.getTimeline.getCreationDateTime.toInstant
+      )
+    }
+  }
+}
+
+object EMR {
+
+  def client(profileName: String, region: Region): AmazonElasticMapReduceAsync = {
+    AmazonElasticMapReduceAsyncClientBuilder.standard()
+      .withCredentials(new ProfileCredentialsProvider(profileName))
+      .withRegion(region.getName)
+      .build()
+  }
+}

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -6,7 +6,8 @@ import com.amazonaws.services.simplesystemsmanagement.model._
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagementAsync, AWSSimpleSystemsManagementAsyncClientBuilder}
 import com.gu.ssm.{CommandStatus, _}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import com.gu.ssm.utils.attempt.{Attempt}
+import com.gu.ssm.model.InstanceId
+import com.gu.ssm.utils.attempt.Attempt
 
 import collection.JavaConverters._
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/com/gu/ssm/model/ExecutionTarget.scala
+++ b/src/main/scala/com/gu/ssm/model/ExecutionTarget.scala
@@ -1,0 +1,20 @@
+package com.gu.ssm.model
+
+import java.time.Instant
+
+
+sealed trait ExecutionTarget
+
+case class InstanceId(id: String) extends AnyVal
+
+case class InstanceIds(ids: List[InstanceId])
+  extends ExecutionTarget
+
+case class Instance(id: InstanceId, publicIpAddressOpt: Option[String], launchInstant: Instant)
+  extends ExecutionTarget
+
+case class EMRClusterId(id: String)
+  extends ExecutionTarget
+
+case class AppStackStage(app: String, stack: String, stage: String)
+  extends ExecutionTarget

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -6,12 +6,21 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsync
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
 import java.time.Instant
 
-case class InstanceId(id: String) extends AnyVal
-case class Instance(id: InstanceId, publicIpAddressOpt: Option[String], launchInstant: Instant)
-case class AppStackStage(app: String, stack: String, stage: String)
-case class ExecutionTarget(instances: Option[List[InstanceId]] = None, ass: Option[AppStackStage] = None)
+import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduceAsync
+import com.gu.ssm.model.{ExecutionTarget, Instance, InstanceId}
 
-case class Arguments(executionTarget: Option[ExecutionTarget], toExecute: Option[String], profile: Option[String], region: Region, mode: Option[SsmMode], singleInstanceSelectionMode: SingleInstanceSelectionMode, isSelectionModeNewest: Boolean, isSelectionModeOldest: Boolean)
+
+case class Arguments(
+  executionTarget: Option[ExecutionTarget],
+  toExecute: Option[String],
+  profile: Option[String],
+  region: Region,
+  mode: Option[SsmMode],
+  singleInstanceSelectionMode: SingleInstanceSelectionMode,
+  isSelectionModeNewest: Boolean,
+  isSelectionModeOldest: Boolean
+)
+
 object Arguments {
   def empty(): Arguments = Arguments(None, None, None, Region.getRegion(Regions.EU_WEST_1), None, SismUnspecified, false, false)
 }
@@ -41,9 +50,10 @@ case class SSMConfig (
 )
 
 case class AWSClients (
-  ssmClient: AWSSimpleSystemsManagementAsync,
-  stsClient: AWSSecurityTokenServiceAsync,
-  ec2Client: AmazonEC2Async
+  ssm: AWSSimpleSystemsManagementAsync,
+  sts: AWSSecurityTokenServiceAsync,
+  ec2: AmazonEC2Async,
+  emr: AmazonElasticMapReduceAsync
 )
 
 case class ResultsWithInstancesNotFound(results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])], instancesNotFound: List[InstanceId])

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -3,6 +3,8 @@ package com.gu.ssm
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
 import java.time.{LocalDateTime, ZoneId}
 
+import com.gu.ssm.model.{AppStackStage, Instance, InstanceId}
+
 class LogicTest extends FreeSpec with Matchers with EitherValues {
   "extractSASTags" - {
     import Logic.extractSASTags

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -2,18 +2,19 @@ package com.gu.ssm
 
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
 import com.gu.ssm.Logic.computeIncorrectInstances
+import com.gu.ssm.model.{InstanceId, InstanceIds}
 
 
 class MainTest extends FreeSpec with Matchers with EitherValues {
 
   "computeIncorrectInstances" - {
     "should return empty list when matching list of Instance Ids" in {
-      val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"))))
+      val executionTarget = InstanceIds(List(InstanceId("i-096fdd62fd48b5b99")))
       val instanceIds = List(InstanceId("i-096fdd62fd48b5b99"))
       computeIncorrectInstances(executionTarget, instanceIds) shouldEqual Nil
     }
     "should return incorrectly submitted Instance Id" in {
-      val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"),InstanceId("i-12345"))))
+      val executionTarget = InstanceIds(List(InstanceId("i-096fdd62fd48b5b99"),InstanceId("i-12345")))
       val instanceIds = List(InstanceId("i-096fdd62fd48b5b99"))
       computeIncorrectInstances(executionTarget, instanceIds) shouldEqual List(InstanceId("i-12345"))
     }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -4,6 +4,8 @@ import org.scalatest.{EitherValues, FreeSpec, Matchers}
 import java.io.File
 import java.time.Instant
 
+import com.gu.ssm.model.{Instance, InstanceId}
+
 class SSHTest extends FreeSpec with Matchers with EitherValues {
 
   "create add key command" - {


### PR DESCRIPTION
This adds a new flag to facilitate executing commands on EMR master instances. This will be useful for e.g. using the interactive Hive shell on an instance.  I've also done a touch of refactoring (mainly to split out `ExecutionTarget` to  a trait instead of a single class with optional fields).

Note that I haven't tested anything yet, this is just to get some feedback on the basic idea. 