### PR TITLE
Detect `InvocationDoesNotExistException` by type rather than message text

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Note that if the argument `-t <app>,<stack>,<stage>` resolves to more than one i
 During development, the program can be run using sbt, either from an
 sbt shell or from the CLI in that project.
 
-    $ sbt "run --c pwd --instances i-0123456 --profile xxx --region xxx"
+    $ sbt "run cmd -c pwd --instances i-0123456 --profile xxx --region xxx"
 
-    sbt:ssm-scala> run --c pwd --instances i-0123456 --profile xxx --region xxx 
+    sbt:ssm-scala> run cmd -c pwd --instances i-0123456 --profile xxx --region xxx 
 
 However, `sbt` traps the program exit so in REPL mode you may find it
 easier to create and run an executable instead, for this just run 

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -42,7 +42,7 @@ object SSM {
     handleAWSErrs(
       awsToScala(client.getCommandInvocationAsync)(request)
         .map(extractCommandResult)
-        .recover { case e if e.getMessage.contains("InvocationDoesNotExist") => Left(InvocationDoesNotExist) }
+        .recover { case _:InvocationDoesNotExistException => Left(InvocationDoesNotExist) }
     )
   }
 


### PR DESCRIPTION
We can take advantage of the strongly-typed `InvocationDoesNotExistException` provided by the AWS SDK. This doesn't make the fix introduced with d9d691e in #34 any better, just a bit more concise, and more strongly-typed!

