### PR TITLE
Add templates for PRs and issues, and contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Opening a pull request
+
+## General
+
+Pull requests are welcome! Here are the rules of engagement:
+
+- The philosophy here is about communication, taking responsibility for your changes, and fast, incremental delivery.
+- Speak to the team before you decide to do anything major. We can probably help design the change to maximise the chances of it being accepted.
+- Pull requests made to master assume the change is ready to be released.
+- Many small requests will be reviewed/merged quicker than a giant lists of changes.
+- If you have a proposal, or want feedback on a branch under development, prefix `[WIP]` to the pull request title.
+
+### Please be aware that we use the Apache License 2.0, and so:
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+Your contributions should be wholly your own.
+
+## Submission
+
+### Guardian employees
+
+This is applicable to [GMG employees](http://www.gmgplc.co.uk/).
+
+1. Fork or clone the repo and make your changes.
+
+2. Test your branch locally by running tests:
+    - `./sbt project <project>/test`
+
+3. Open a pull request:
+    - Explain why you are making this change in the pull request
+
+4. A member of the team will review the changes. Once they are satisfied they will approve the pull request.
+
+
+### External contributions
+
+Firstly, thanks for helping make our project better! Secondly, we'll try and make this as simple as possible.
+
+- Fork the project on GitHub, patch the code, and submit a pull request.
+- We will test, verify and merge your changes and then deploy the code.
+- Certain contributions may require a Contributor License Agreement.
+
+Finally, have you considered [working for us](https://workforus.theguardian.com/index.php/search-jobs-and-apply/?search_paths%5B%5D=&query=developer)?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+# ISSUE
+
+## Steps to Reproduce
+
+
+## Actual Results (include screenshots)
+
+
+## Expected Results (include screenshots)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What does this change?
+
+<!-- Screenshots may be helpful to demonstrate -->
+
+
+
+## What is the value of this?
+
+
+
+## Any additional notes?


### PR DESCRIPTION
## What does this change?

Adds contributing guidelines and issue/PR templates similar to those found in other Guardian repositories

## What is the value of this?

- More detail in issues and PRs
- Makes it easier for people outside the team or The Guardian to contribute

## Any additional notes?

Potentially, some of the notes on developing/contributing that are currently in the README could be moved to CONTRIBUTING.md

YMMV 😁 