### PR TITLE
Introduces --raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create and upload a temporary ssh key
   --newest                 Selects the newest instance if more than one instance was specified
   --oldest                 Selects the oldest instance if more than one instance was specified
   --private                Use private IP address (must be routable via VPN Gateway)
+  --machine                Use private IP address (must be routable via VPN Gateway)
 ```
 
 There are two mandatory configuration items.
@@ -119,6 +120,16 @@ The instance must already have both a public IP address _and_
 appropriate security groups.
 
 Note that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to proceed with one single instance using the command line flags `--oldest` and `--newest`, which select either the oldest or newest instances.
+
+### --machine
+
+This flag allows for a pipe-able ssh connection string. For instance
+
+```
+ssm ssh --profile security -t security-hq,security,PROD --newest --machine | bash
+```
+
+Will automatically ssh you to the newest instance running security-hq. Note that you still have to manually accept the new ECDSA key fingerprint.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Create and upload a temporary ssh key
   --newest                 Selects the newest instance if more than one instance was specified
   --oldest                 Selects the oldest instance if more than one instance was specified
   --private                Use private IP address (must be routable via VPN Gateway)
-  --raw                    Use private IP address (must be routable via VPN Gateway)
+  --raw                    Unix pipe-able ssh connection string
 ```
 
 There are two mandatory configuration items.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Create and upload a temporary ssh key
   --newest                 Selects the newest instance if more than one instance was specified
   --oldest                 Selects the oldest instance if more than one instance was specified
   --private                Use private IP address (must be routable via VPN Gateway)
-  --machine                Use private IP address (must be routable via VPN Gateway)
+  --raw                    Use private IP address (must be routable via VPN Gateway)
 ```
 
 There are two mandatory configuration items.
@@ -121,12 +121,12 @@ appropriate security groups.
 
 Note that if the argument `-t <app>,<stack>,<stage>` resolves to more than one instance, the command will stop with an error message. You can circumvent this behaviour and instruct `ssm` to proceed with one single instance using the command line flags `--oldest` and `--newest`, which select either the oldest or newest instances.
 
-### --machine
+### --raw
 
 This flag allows for a pipe-able ssh connection string. For instance
 
 ```
-ssm ssh --profile security -t security-hq,security,PROD --newest --machine | bash
+ssm ssh --profile security -t security-hq,security,PROD --newest --raw | bash
 ```
 
 Will automatically ssh you to the newest instance running security-hq. Note that you still have to manually accept the new ECDSA key fingerprint.

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -90,10 +90,10 @@ object ArgumentParser {
               usePrivateIpAddress = true)
           })
           .text("unix pipe-able ssh connection string"),
-        opt[Unit]("machine").optional()
+        opt[Unit]("raw").optional()
           .action((_, args) => {
             args.copy(
-              machineOutput = true)
+              rawOutput = true)
           })
           .text("Use private IP address (must be routable via VPN Gateway)"),
         checkConfig( c =>

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -89,6 +89,12 @@ object ArgumentParser {
             args.copy(
               usePrivateIpAddress = true)
           })
+          .text("unix pipe-able ssh connection string"),
+        opt[Unit]("machine").optional()
+          .action((_, args) => {
+            args.copy(
+              machineOutput = true)
+          })
           .text("Use private IP address (must be routable via VPN Gateway)"),
         checkConfig( c =>
           if (c.isSelectionModeOldest && c.isSelectionModeNewest) failure("You cannot both specify --newest and --oldest")

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, usePrivate)) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, usePrivate, machineOutput)) =>
         val awsClients = Logic.getClients(profile, region)
         mode match {
           case SsmRepl =>

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -45,7 +45,7 @@ object Main {
       _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
       _ <- IO.installSshKey(instance.id, config.name, addAndRemoveKeyCommand, awsClients.ssmClient)
       ipAddress <- Attempt.fromEither(Logic.getIpAddress(instance, usePrivate))
-    } yield SSH.sshCmd(authFile, instance, user, ipAddress, machineOutput)
+    } yield SSH.sshCmd(machineOutput)(authFile, instance, user, ipAddress)
 
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput(machineOutput))

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, usePrivate, machineOutput)) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, usePrivate, rawOutput)) =>
         val awsClients = Logic.getClients(profile, region)
         mode match {
           case SsmRepl =>
@@ -23,7 +23,7 @@ object Main {
               case _ => fail()
             }
           case SsmSsh =>
-            setUpSSH(awsClients, executionTarget, user, sism, usePrivate, machineOutput)
+            setUpSSH(awsClients, executionTarget, user, sism, usePrivate, rawOutput)
         }
       case Some(_) => fail()
       case None => System.exit(ArgumentsError.code) // parsing cmd line args failed, help message will have been displayed

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -60,7 +60,7 @@ object SSH {
       | /bin/sed -i '/${authKey.replaceAll("/", "\\\\/")}/d' /home/$user/.ssh/authorized_keys;
       |""".stripMargin
 
-  def sshCmd(tempFile: File, instance: Instance, user: String, ipAddress: String, machineOutput: Boolean): (InstanceId, String) = {
+  def sshCmd(machineOutput: Boolean)(tempFile: File, instance: Instance, user: String, ipAddress: String): (InstanceId, String) = {
     val connectionString = s"ssh -i ${tempFile.getCanonicalFile.toString} $user@$ipAddress"
     val cmd = if(machineOutput) {
       connectionString

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -60,9 +60,9 @@ object SSH {
       | /bin/sed -i '/${authKey.replaceAll("/", "\\\\/")}/d' /home/$user/.ssh/authorized_keys;
       |""".stripMargin
 
-  def sshCmd(machineOutput: Boolean)(tempFile: File, instance: Instance, user: String, ipAddress: String): (InstanceId, String) = {
+  def sshCmd(rawOutput: Boolean)(tempFile: File, instance: Instance, user: String, ipAddress: String): (InstanceId, String) = {
     val connectionString = s"ssh -i ${tempFile.getCanonicalFile.toString} $user@$ipAddress"
-    val cmd = if(machineOutput) {
+    val cmd = if(rawOutput) {
       connectionString
     }else{
       s"""

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -60,12 +60,16 @@ object SSH {
       | /bin/sed -i '/${authKey.replaceAll("/", "\\\\/")}/d' /home/$user/.ssh/authorized_keys;
       |""".stripMargin
 
-  def sshCmd(tempFile: File, instance: Instance, user: String, ipAddress: String): (InstanceId, String) = {
-    val cmd = s"""
-      | # Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:
-      | ssh -i ${tempFile.getCanonicalFile.toString} $user@$ipAddress;
-      |""".stripMargin
+  def sshCmd(tempFile: File, instance: Instance, user: String, ipAddress: String, machineOutput: Boolean): (InstanceId, String) = {
+    val connectionString = s"ssh -i ${tempFile.getCanonicalFile.toString} $user@$ipAddress"
+    val cmd = if(machineOutput) {
+      connectionString
+    }else{
+      s"""
+         | # Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:
+         | ${connectionString};
+         |""".stripMargin
+    }
     (instance.id, cmd)
   }
-
 }

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -22,8 +22,8 @@ object UI {
     }
   }
 
-  def sshOutput(machineOutput: Boolean)(result: (InstanceId, String)): Unit = {
-    if (machineOutput){
+  def sshOutput(rawOutput: Boolean)(result: (InstanceId, String)): Unit = {
+    if (rawOutput){
       print(result._2)
     } else {
       UI.printMetadata(s"========= ${result._1.id} =========")

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -22,10 +22,14 @@ object UI {
     }
   }
 
-  def sshOutput(result: (InstanceId, String)): Unit = {
-    UI.printMetadata(s"========= ${result._1.id} =========")
-    UI.printMetadata(s"STDOUT:")
-    println(result._2)
+  def sshOutput(machineOutput: Boolean)(result: (InstanceId, String)): Unit = {
+    if (machineOutput){
+      print(result._2)
+    } else {
+      UI.printMetadata(s"========= ${result._1.id} =========")
+      UI.printMetadata(s"STDOUT:")
+      println(result._2)
+    }
   }
 
   def outputFailure(failedAttempt: FailedAttempt): Unit = {

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -22,7 +22,7 @@ case class Arguments(
   isSelectionModeNewest: Boolean,
   isSelectionModeOldest: Boolean,
   usePrivateIpAddress: Boolean,
-  machineOutput: Boolean
+  rawOutput: Boolean
 )
 object Arguments {
   val DefaultUser = "ubuntu"
@@ -38,7 +38,7 @@ object Arguments {
     isSelectionModeNewest = false,
     isSelectionModeOldest = false,
     usePrivateIpAddress = false,
-    machineOutput = false
+    rawOutput = false
   )
 }
 

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -21,7 +21,8 @@ case class Arguments(
   singleInstanceSelectionMode: SingleInstanceSelectionMode,
   isSelectionModeNewest: Boolean,
   isSelectionModeOldest: Boolean,
-  usePrivateIpAddress: Boolean
+  usePrivateIpAddress: Boolean,
+  machineOutput: Boolean
 )
 object Arguments {
   val DefaultUser = "ubuntu"
@@ -36,7 +37,8 @@ object Arguments {
     singleInstanceSelectionMode = SismUnspecified,
     isSelectionModeNewest = false,
     isSelectionModeOldest = false,
-    usePrivateIpAddress = false
+    usePrivateIpAddress = false,
+    machineOutput = false
   )
 }
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -51,12 +51,21 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
     import SSH.sshCmd
     import java.util.Date
 
-    "create ssh command" in {
+    "create ssh command" - {
       val file = new File("/banana")
       val instance = Instance(InstanceId("raspberry"), Some("34.1.1.10"), "10.1.1.10", Instant.now())
-      val cmd = sshCmd(file, instance, "user4", "34.1.1.10", false)
-      cmd._1.id shouldEqual "raspberry"
-      cmd._2 should include ("ssh -i /banana user4@34.1.1.10")
+
+      "user command" in {
+        val cmd = sshCmd(false)(file, instance, "user4", "34.1.1.10")
+        cmd._1.id shouldEqual "raspberry"
+        cmd._2 should include ("ssh -i /banana user4@34.1.1.10")
+      }
+
+      "machine command" in {
+        val cmd = sshCmd(true)(file, instance, "user4", "34.1.1.10")
+        cmd._1.id shouldEqual "raspberry"
+        cmd._2 should include ("ssh -i /banana user4@34.1.1.10")
+      }
     }
   }
 }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -66,6 +66,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
         cmd._1.id shouldEqual "raspberry"
         cmd._2 should include ("ssh -i /banana user4@34.1.1.10")
       }
+
     }
   }
 }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -54,7 +54,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
     "create ssh command" in {
       val file = new File("/banana")
       val instance = Instance(InstanceId("raspberry"), Some("34.1.1.10"), "10.1.1.10", Instant.now())
-      val cmd = sshCmd(file, instance, "user4", "34.1.1.10")
+      val cmd = sshCmd(file, instance, "user4", "34.1.1.10", false)
       cmd._1.id shouldEqual "raspberry"
       cmd._2 should include ("ssh -i /banana user4@34.1.1.10")
     }


### PR DESCRIPTION
This change introduces the `--raw` flag for the ssh subcommand allowing the output to be used as part of a pipe. For instance

```
ssm ssh --profile security -t security-hq,security,PROD --newest --raw | bash
```

will execute the ssh connection directly. 

Note that we moved from 

```
sshOutput(result: (InstanceId, String))
``` 

to

```
sshOutput(machineOutput: Boolean)(result: (InstanceId, String))
``` 

as the best way to keep `setUpSSH`'s `programResult.fold` clean.