### PR TITLE
Handle pseudo-terminal for raw

### DIFF
--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -63,7 +63,7 @@ object SSH {
   def sshCmd(rawOutput: Boolean)(tempFile: File, instance: Instance, user: String, ipAddress: String): (InstanceId, String) = {
     val connectionString = s"ssh -i ${tempFile.getCanonicalFile.toString} $user@$ipAddress"
     val cmd = if(rawOutput) {
-      connectionString
+      s"$connectionString -t -t"
     }else{
       s"""
          | # Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -64,7 +64,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       "machine command" in {
         val cmd = sshCmd(true)(file, instance, "user4", "34.1.1.10")
         cmd._1.id shouldEqual "raspberry"
-        cmd._2 should include ("ssh -i /banana user4@34.1.1.10")
+        cmd._2 should include ("ssh -i /banana user4@34.1.1.10 -t -t")
       }
 
     }


### PR DESCRIPTION
## What does this change?

Forces pseudo terminal allocation for --raw invocation

## What is the value of this?

--raw is usually piped to bash, which requires a pseudo terminal to be forced

## Any additional notes?

No