### PR TITLE
Remove bashisms

### DIFF
--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -39,12 +39,13 @@ object SSH {
 
   def addTaintedCommand(name: String): String = {
     s"""
-       | [[ -f /etc/update-motd.d/99-tainted ]] || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
-       | /bin/echo -e 'echo -e "\033[0;31mThis instance should be considered tainted.\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
-       | /bin/echo -e 'echo -e "\033[0;31mIt was accessed by $name at ${Calendar.getInstance().getTime}\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
-       | /usr/bin/sudo /bin/chmod 0755 /etc/update-motd.d/99-tainted;
-       | /usr/bin/sudo /bin/run-parts /etc/update-motd.d/ | /usr/bin/sudo /usr/bin/tee /run/motd.dynamic >> /dev/null;
-       | """.stripMargin
+       | /usr/bin/test -d /etc/update-motd.d/ &&
+       | ( /usr/bin/test -f /etc/update-motd.d/99-tainted || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
+       |   /bin/echo -e 'echo -e "\033[0;31mThis instance should be considered tainted.\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
+       |   /bin/echo -e 'echo -e "\033[0;31mIt was accessed by $name at ${Calendar.getInstance().getTime}\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
+       |   /usr/bin/sudo /bin/chmod 0755 /etc/update-motd.d/99-tainted;
+       |   /usr/bin/sudo /bin/run-parts /etc/update-motd.d/ | /usr/bin/sudo /usr/bin/tee /run/motd.dynamic >> /dev/null;
+       | ) """.stripMargin
   }
 
   def addKeyCommand(user: String, authKey: String): String =

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -24,6 +24,7 @@ object UI {
 
   def sshOutput(rawOutput: Boolean)(result: (InstanceId, String)): Unit = {
     if (rawOutput){
+      Thread.sleep(1000)
       print(result._2)
     } else {
       UI.printMetadata(s"========= ${result._1.id} =========")

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -27,7 +27,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
     "ensure motd command file is present" in {
       import SSH.addTaintedCommand
-      addTaintedCommand("XXX") should include ("[[ -f /etc/update-motd.d/99-tainted ]] || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;")
+      addTaintedCommand("XXX") should include ("test -f /etc/update-motd.d/99-tainted || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;")
     }
     "ensure motd command file contains tainted message" in {
       import SSH.addTaintedCommand


### PR DESCRIPTION
## What does this change?

Posix compliance - does not rely on root having a bash shell by default

## What is the value of this?

Will work on machines which do not use bash for root.

## Any additional notes?

Also introduces a one second delay before output in "--raw | bash" mode, which should prevent the race condition between adding the key and invoking the command in bash.