### PR TITLE
Clarifying the use of --private for bastions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ ssm ssh --profile <profile-name> --bastion i-bastion12345 --bastion-port 2022 --
 
 It is possible to specify the user used for connecting to the bastion, this is done with the `--bastion-user <value>` command line argument.
 
+### Bastions with private IP addresses
+
+When using the standard `ssh` command, the `--private` flag can be used to indicate that the private IP of the target instance should be used for the connection. In the case of bastion connection the target instance is assumed to always be reacheable through a private IP and this flag indicates whether the private IP of the bastion should be used.
+
 ## Development
 
 During development, the program can be run using sbt, either from an sbt shell or from the CLI in that project.

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -58,9 +58,9 @@ object Main {
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (privateKeyFile, publicKey) = sshArtifacts
       bastionConfig <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, ExecutionTarget(Some(List(InstanceId(bastionInstanceId)))))
-      bastionInstance <- Attempt.fromEither(Logic.getSSHInstance(bastionConfig.targets, SismUnspecified, false))
+      bastionInstance <- Attempt.fromEither(Logic.getSSHInstance(bastionConfig.targets, SismUnspecified, usePrivate))
       bastionAddAndRemovePublicKeyCommand = SSH.addPublicKeyCommand(user, publicKey) + SSH.removePublicKeyCommand(user, publicKey)
-      bastionAddress <- Attempt.fromEither(Logic.getAddress(bastionInstance, false))
+      bastionAddress <- Attempt.fromEither(Logic.getAddress(bastionInstance, usePrivate))
       targetConfig <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
       targetInstance <- Attempt.fromEither(Logic.getSSHInstance(targetConfig.targets, sism, true))
       targetAddress <- Attempt.fromEither(Logic.getAddress(targetInstance, true))


### PR DESCRIPTION
This change removes the assumption that bastions always have a public IP address, and update the documentation accordingly.