### PR TITLE
Better error message for expired AWS credentials

### DIFF
--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -25,7 +25,7 @@ object AwsAsyncHandler {
         case ServiceName(serviceName) => Some(serviceName)
         case _ => None
       }
-      if (e.getMessage.contains("The security token included in the request is expired")) {
+      if (e.getMessage.contains("Request has expired")) {
         Failure("expired AWS credentials", "Failed to request data from AWS, the temporary credentials have expired", AwsPermissionsError).attempt
       } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
         Failure("Invalid AWS profile name (no credentials)", "No credentials found for the specified AWS profile", AwsPermissionsError).attempt


### PR DESCRIPTION
Before:

```
$ ./ssm cmd -c "ls" -p security --tags security-hq,security,PROD
Unknown error while making an API call to AWS' AmazonEC2 service, Request has expired. (Service: AmazonEC2; Status Code: 400; Error Code: RequestExpired; Request ID: db00d551-f2d1-4959-ad2f-310616648b7e)
```

After:

```
$ ./ssm cmd -c "ls" -p security --tags security-hq,security,PROD
Failed to request data from AWS, the temporary credentials have expired
```
