### PR TITLE
Unbump version pending further work to support Discussion team

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ java -jar <path-to-jar>/ssm.jar [arguments]
 
 To release a new version of `ssm` perform the two following tasks:
 
+1. Update the version number in `build.sbt`
+
 1. Generate a new executable. Run the following at the top of the repository
  
 	```

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion := "2.12.4"
 
 name := "ssm-scala"
 organization := "com.gu"
-version := "1.0.0"
+version := "0.9.1"
 
 val awsSdkVersion = "1.11.258"
 


### PR DESCRIPTION
## What does this change?

Rebump version to 0.9.1 prior to release for homebrew.

## What is the value of this?

Release including --execute without marking as v1

## Any additional notes?