### PR TITLE
Introduces the -a, --agent flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Create and upload a temporary ssh key
   --oldest                 Selects the oldest instance if more than one instance was specified
   --private                Use private IP address (must be routable via VPN Gateway)
   --raw                    Unix pipe-able ssh connection string
+  -a, --agent              Use the local ssh agent to register the private key (and do not use -i)
   --bastion <value>        Connect through the given bastion specified by its instance id
   --bastion-port <value>   Connect through the given bastion at a given port
   --bastion-user <value>   Connect to bastion as this user (default: ubuntu)
@@ -190,6 +191,33 @@ It is possible to specify the user used for connecting to the bastion, this is d
 ### Bastions with private IP addresses
 
 When using the standard `ssh` command, the `--private` flag can be used to indicate that the private IP of the target instance should be used for the connection. In the case of bastion connection the target instance is assumed to always be reacheable through a private IP and this flag indicates whether the private IP of the bastion should be used.
+
+### Bastions with private keys problems
+
+There's been occurences of bastions connections strings of the form 
+
+```
+ssh -A -i /path/to/temp/private/key -t -t ubuntu@bastion-hostname \ 
+    -t -t ssh -t -t ubuntu@target-ip-address;
+```
+
+not working, because the private file was not found for the second ssh connection, leading to a "Permission denied (publickey)" error message. 
+
+When this happens the user can use the `-a`, `--agent` flag that performs a registration of the private key at the local ssh agent. With this flag, ssm command
+
+```
+ssm ssh --profile <account-name> --bastion <instanceId1> \
+    -i <instanceId2> --agent
+``` 
+
+returns
+
+```
+ssh-add /path/to/temp/private/key && \
+    ssh -A ubuntu@bastion-hostname \
+    -t -t ssh ubuntu@target-ip-address;
+```
+ 
 
 ## Development
 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -105,6 +105,12 @@ object ArgumentParser {
               rawOutput = true)
           })
           .text("Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"),
+        opt[Unit]('a', "agent").optional()
+          .action((_, args) => {
+            args.copy(
+              useAgent = true)
+          })
+          .text("Use the local ssh agent to register the private key (and do not use -i); only bastion connections"),
         opt[String]("bastion").optional()
           .action((bastion, args) => args.copy(bastionInstanceId = Some(bastion)))
           .text(s"Connect through the given bastion specified by its instance id"),

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, usePrivate, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt)) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, usePrivate, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent)) =>
         val awsClients = Logic.getClients(profile, region)
         mode match {
           case SsmRepl =>
@@ -24,7 +24,7 @@ object Main {
             }
           case SsmSsh => bastionInstanceIdOpt match {
             case None => setUpStandardSSH(awsClients, executionTarget, user, sism, usePrivate, rawOutput, targetInstancePortNumberOpt)
-            case Some(bastionInstanceId) => setUpBastionSSH(awsClients, executionTarget, user, sism, usePrivate, rawOutput, bastionInstanceId, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt)
+            case Some(bastionInstanceId) => setUpBastionSSH(awsClients, executionTarget, user, sism, usePrivate, rawOutput, bastionInstanceId, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent)
           }
         }
       case Some(_) => fail()
@@ -53,7 +53,7 @@ object Main {
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 
-  private def setUpBastionSSH(awsClients: AWSClients, executionTarget: ExecutionTarget, user: String, sism: SingleInstanceSelectionMode, usePrivate: Boolean, rawOutput: Boolean, bastionInstanceId: String, bastionPortNumberOpt: Option[Int], bastionUser: String,  targetInstancePortNumberOpt: Option[Int]) = {
+  private def setUpBastionSSH(awsClients: AWSClients, executionTarget: ExecutionTarget, user: String, sism: SingleInstanceSelectionMode, usePrivate: Boolean, rawOutput: Boolean, bastionInstanceId: String, bastionPortNumberOpt: Option[Int], bastionUser: String,  targetInstancePortNumberOpt: Option[Int], useAgent: Boolean) = {
     val fProgramResult = for {
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (privateKeyFile, publicKey) = sshArtifacts
@@ -68,7 +68,7 @@ object Main {
       _ <- IO.installSshKey(bastionInstance.id, bastionConfig.name, bastionAddAndRemovePublicKeyCommand, awsClients.ssmClient)
       _ <- IO.tagAsTainted(targetInstance.id, targetConfig.name, awsClients.ec2Client)
       _ <- IO.installSshKey(targetInstance.id, targetConfig.name, targetAddAndRemovePublicKeyCommand, awsClients.ssmClient)
-    } yield SSH.sshCmdBastion(rawOutput)(privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt)
+    } yield SSH.sshCmdBastion(rawOutput)(privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent)
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
     System.exit(programResult.fold(_.exitCode, _ => 0))

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -90,8 +90,8 @@ object SSH {
     } else {
       s"ssh -A${bastionPortSpecifications}${stringFragmentMinusIOption}${stringFragmentTTOptions} $bastionUser@$bastionIpAddress"
     }
-    val stringFragmentTargetConnection = s"ssh${targetPortSpecifications}${stringFragmentTTOptions} $targetInstanceUser@$targetIpAddress"
-    val connectionString = s"${stringFragmentSshAdd}${stringFragmentBastionConnection} -t -t ${stringFragmentTargetConnection}"
+    val stringFragmentTargetConnection = s"-t -t ssh${targetPortSpecifications}${stringFragmentTTOptions} $targetInstanceUser@$targetIpAddress"
+    val connectionString = s"${stringFragmentSshAdd}${stringFragmentBastionConnection} ${stringFragmentTargetConnection}"
     val cmd = if(rawOutput) {
       s"$connectionString"
     }else{

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -79,19 +79,19 @@ object SSH {
     (instance.id, cmd)
   }
 
-  def sshCmdBastion(rawOutput: Boolean)(privateKeyFile: File, bastionInstance: Instance, targetInstance: Instance, targetInstanceUser: String, bastionIpAddress: String, targetIpAddress: String, bastionPortNumberOpt: Option[Int], bastionUser: String, targetInstancePortNumberOpt: Option[Int]): (InstanceId, String) = {
-    val bastionPortSpecifications = bastionPortNumberOpt match {
-      case Some(portNumber) => s" -p ${portNumber}" // trailing space is important
-      case _ => ""
+  def sshCmdBastion(rawOutput: Boolean)(privateKeyFile: File, bastionInstance: Instance, targetInstance: Instance, targetInstanceUser: String, bastionIpAddress: String, targetIpAddress: String, bastionPortNumberOpt: Option[Int], bastionUser: String, targetInstancePortNumberOpt: Option[Int], useAgent: Boolean): (InstanceId, String) = {
+    val stringFragmentSshAdd = if(useAgent) { s"ssh-add ${privateKeyFile.getCanonicalFile.toString} && " } else { "" }
+    val bastionPortSpecifications = bastionPortNumberOpt.map( port => s" -p ${port}" ).getOrElse("")
+    val targetPortSpecifications = targetInstancePortNumberOpt.map( port => s" -p ${port}" ).getOrElse("")
+    val stringFragmentTTOptions = if(rawOutput) { " -t -t" } else { "" }
+    val stringFragmentMinusIOption = if(useAgent) { "" } else { s" -i ${privateKeyFile.getCanonicalFile.toString}" }
+    val stringFragmentBastionConnection = if(useAgent) {
+      s"ssh -A${bastionPortSpecifications}${stringFragmentTTOptions} $bastionUser@$bastionIpAddress"
+    } else {
+      s"ssh -A${bastionPortSpecifications}${stringFragmentMinusIOption}${stringFragmentTTOptions} $bastionUser@$bastionIpAddress"
     }
-    val targetPortSpecifications = targetInstancePortNumberOpt match {
-      case Some(portNumber) => s" -p ${portNumber}" // trailing space is important
-      case _ => ""
-    }
-    val theTTOptions = if(rawOutput) { " -t -t" }else{ "" }
-    val connectionString1 = s"ssh -A${bastionPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $bastionUser@$bastionIpAddress"
-    val connectionString2 = s"ssh${targetPortSpecifications}${theTTOptions} $targetInstanceUser@$targetIpAddress"
-    val connectionString = s"${connectionString1} -t -t ${connectionString2}"
+    val stringFragmentTargetConnection = s"ssh${targetPortSpecifications}${stringFragmentTTOptions} $targetInstanceUser@$targetIpAddress"
+    val connectionString = s"${stringFragmentSshAdd}${stringFragmentBastionConnection} -t -t ${stringFragmentTargetConnection}"
     val cmd = if(rawOutput) {
       s"$connectionString"
     }else{

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -26,7 +26,8 @@ case class Arguments(
   bastionInstanceId: Option[String],
   bastionPortNumber: Option[Int],
   bastionUser: Option[String],
-  targetInstancePortNumber: Option[Int]
+  targetInstancePortNumber: Option[Int],
+  useAgent: Boolean
 )
 
 object Arguments {
@@ -48,7 +49,8 @@ object Arguments {
     bastionInstanceId = None,
     bastionPortNumber = None,
     bastionUser = Some(bastionDefaultUser),
-    targetInstancePortNumber = None
+    targetInstancePortNumber = None,
+    useAgent = false
   )
 }
 


### PR DESCRIPTION
There's been occurences of bastions connections strings of the form

```
ssh -A -i /path/to/temp/private/key -t -t ubuntu@bastion-hostname \
    -t -t ssh -t -t ubuntu@target-ip-address;
```

not working, because the private file was not found for the second ssh connection, leading to a "Permission denied (publickey)" error message.

When this happens the user can use the `-a`, `--agent` flag that performs a registration of the private key at the local ssh agent. With this flag, ssm command

```
ssm ssh --profile <account-name> --bastion <instanceId1> \
    -i <instanceId2> --agent
```

returns

```
ssh-add /path/to/temp/private/key && \
    ssh -A ubuntu@bastion-hostname \
    -t -t ssh ubuntu@target-ip-address;
```
