### PR TITLE
Limit agent registration time to prevent "Received disconnect (...) Too many authentication failures" error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion := "2.12.4"
 
 name := "ssm-scala"
 organization := "com.gu"
-version := "0.9.2"
+version := "0.9.3"
 
 val awsSdkVersion = "1.11.258"
 

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -80,7 +80,7 @@ object SSH {
   }
 
   def sshCmdBastion(rawOutput: Boolean)(privateKeyFile: File, bastionInstance: Instance, targetInstance: Instance, targetInstanceUser: String, bastionIpAddress: String, targetIpAddress: String, bastionPortNumberOpt: Option[Int], bastionUser: String, targetInstancePortNumberOpt: Option[Int], useAgent: Boolean): (InstanceId, String) = {
-    val stringFragmentSshAdd = if(useAgent) { s"ssh-add ${privateKeyFile.getCanonicalFile.toString} && " } else { "" }
+    val stringFragmentSshAdd = if(useAgent) { s"ssh-add -t $sshCredentialsLifetimeSeconds ${privateKeyFile.getCanonicalFile.toString} && " } else { "" }
     val bastionPortSpecifications = bastionPortNumberOpt.map( port => s" -p ${port}" ).getOrElse("")
     val targetPortSpecifications = targetInstancePortNumberOpt.map( port => s" -p ${port}" ).getOrElse("")
     val stringFragmentTTOptions = if(rawOutput) { " -t -t" } else { "" }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -119,7 +119,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, true)
-            command should equal ("ssh-add /banana && ssh -A -t -t bastionuser@34.1.1.10 -t -t ssh -t -t user5@10.1.1.11")
+            command should equal (s"ssh-add -t $sshCredentialsLifetimeSeconds /banana && ssh -A -t -t bastionuser@34.1.1.10 -t -t ssh -t -t user5@10.1.1.11")
           }
         }
 
@@ -131,7 +131,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), true)
-            command should equal ("ssh-add /banana && ssh -A -t -t bastionuser@34.1.1.10 -t -t ssh -p 2345 -t -t user5@10.1.1.11")
+            command should equal (s"ssh-add -t $sshCredentialsLifetimeSeconds /banana && ssh -A -t -t bastionuser@34.1.1.10 -t -t ssh -p 2345 -t -t user5@10.1.1.11")
           }
         }
 
@@ -143,7 +143,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, true)
-            command should equal ("ssh-add /banana && ssh -A -p 1234 -t -t bastionuser@34.1.1.10 -t -t ssh -t -t user5@10.1.1.11")
+            command should equal (s"ssh-add -t $sshCredentialsLifetimeSeconds /banana && ssh -A -p 1234 -t -t bastionuser@34.1.1.10 -t -t ssh -t -t user5@10.1.1.11")
           }
         }
 
@@ -155,7 +155,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), true)
-            command should equal ("ssh-add /banana && ssh -A -p 1234 -t -t bastionuser@34.1.1.10 -t -t ssh -p 2345 -t -t user5@10.1.1.11")
+            command should equal (s"ssh-add -t $sshCredentialsLifetimeSeconds /banana && ssh -A -p 1234 -t -t bastionuser@34.1.1.10 -t -t ssh -p 2345 -t -t user5@10.1.1.11")
           }
         }
       }


### PR DESCRIPTION
This change adds the option -t <number> to the ssh-add command in the bastion connection --agent case. Also version 0.9.3.