### PR TITLE
Ensure correct ownership of the authorized_keys file on target

### DIFF
--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -52,6 +52,7 @@ object SSH {
     s"""
       | /bin/mkdir -p /home/$user/.ssh;
       | /bin/echo '$publicKey' >> /home/$user/.ssh/authorized_keys;
+      | /bin/chown $user /home/$user/.ssh/authorized_keys;
       | /bin/chmod 0600 /home/$user/.ssh/authorized_keys;
       |""".stripMargin
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -17,8 +17,12 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       addPublicKeyCommand("user2", "XXX") should include ("/bin/echo 'XXX' >> /home/user2/.ssh/authorized_keys;")
     }
 
+    "ensure authorised key file ownership is correct" in {
+      addPublicKeyCommand("user3", "XXX") should include ("/bin/chown user3 /home/user3/.ssh/authorized_keys;")
+    }
+
     "ensure authorised key file permissions are correct" in {
-      addPublicKeyCommand("user3", "XXX") should include ("/bin/chmod 0600 /home/user3/.ssh/authorized_keys;")
+      addPublicKeyCommand("user4", "XXX") should include ("/bin/chmod 0600 /home/user4/.ssh/authorized_keys;")
     }
 
   }


### PR DESCRIPTION
On some instances authorized_keys comes owned by root. This change ensures that the file is owned by ubuntu or the default user provided by the user.