### PR TITLE
Introduce new sub command 'scp' for secure copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Otherwise, fetch the most recently released version of the program from the [Git
 The automatically generated help section for `ssm` is
 
 ```
-Usage: ssm [cmd|repl|ssh] [options]
+Usage: ssm [cmd|repl|ssh|scp] [options] <args>...
 
   -p, --profile <value>    The AWS profile name to use for authenticating this execution
   -i, --instances <value>  Specify the instance ID(s) on which the specified command(s) should execute
@@ -63,6 +63,17 @@ Create and upload a temporary ssh key
                            The location of the sshd configuration on the remote host (default: /etc/ssh/sshd_config)
   --host-key-alg-preference <value>
                            The preferred host key algorithms, can be specified multiple times - last is preferred (default: ecdsa-sha2-nistp256, ssh-rsa)
+Command: scp [options] <sourceFile>... <targetFile>...
+Secure Copy
+  -u, --user <value>       Connect to remote host as this user (default: ubuntu)
+  --port <value>           Connect to remote host on this port
+  --newest                 Selects the newest instance if more than one instance was specified
+  --oldest                 Selects the oldest instance if more than one instance was specified
+  --private                Use private IP address (must be routable via VPN Gateway)
+  --raw                    Unix pipe-able scp connection string
+  -x, --execute            Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)
+  <sourceFile>...          Source file for the scp sub command. See README for details
+  <targetFile>...          Target file for the scp sub command. See README for details
 ```
 
 There are two mandatory configuration items.
@@ -270,6 +281,40 @@ ssh-add /path/to/temp/private/key && \
     -t -t ssh ubuntu@target-ip-address;
 ```
  
+
+## Secure Copy
+
+**ssm** support the **scp** sub command for the secure transfer of files and directories.
+
+### Introduction
+
+An example of usage is 
+
+```
+./ssm scp -p account -t app,stack,stage /path/to/file1 :/path/to/file1
+``` 
+
+Which outputs
+
+```
+# simplified version
+scp -i /path/to/identity/file.tmp /path/to/file1 ubuntu@34.242.32.40:/path/to/file2;
+```
+
+Otherwise 
+
+```
+./ssm scp -p account -t app,stack,stage :/path/to/file1 /path/to/file2
+```
+
+outputs 
+
+```
+# simplified version
+scp -i /path/to/identity/file.tmp ubuntu@34.242.32.40:/path/to/file1 /path/to/file2 ;
+```
+
+The convention is: the first (left hand side) file is always the source and the second (right hand side) is always the target and the colon, indicates which one is on the remote server. 
 
 ## Development
 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -197,9 +197,11 @@ object ArgumentParser {
           })
           .text("Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"),
         arg[String]("<sourceFile>...").required()
-          .action( (sourceFile, args) => args.copy(sourceFile = Some(sourceFile)) ),
+          .action( (sourceFile, args) => args.copy(sourceFile = Some(sourceFile)) )
+          .text("Source file for the scp sub command. See README for details"),
         arg[String]("<targetFile>...").required()
-          .action( (targetFile, args) => args.copy(targetFile = Some(targetFile)) ),
+          .action( (targetFile, args) => args.copy(targetFile = Some(targetFile)) )
+          .text("Target file for the scp sub command. See README for details"),
         checkConfig( c =>
           if (c.isSelectionModeOldest && c.isSelectionModeNewest) failure("You cannot both specify --newest and --oldest")
           else success )

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -142,7 +142,7 @@ object Main {
       address <- Attempt.fromEither(Logic.getAddress(instance, onlyUsePrivateIP))
       hostKeyFile <- SSH.writeHostKey((address, hostKey))
     } yield {
-      SSH.scpCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, sourceFile, targetFile)
+      SSH.scpCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile), sourceFile, targetFile)
     }
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, Some(sshdConfigPath), preferredAlgs)) =>
+      case Some(Arguments(Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, Some(sshdConfigPath), preferredAlgs, sourceFileOpt, targetFileOpt)) =>
         val awsClients = Logic.getClients(profile, region)
         mode match {
           case SsmRepl =>
@@ -26,6 +26,11 @@ object Main {
             case None => setUpStandardSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, targetInstancePortNumberOpt, sshdConfigPath, preferredAlgs, useAgent)
             case Some(bastionInstance) => setUpBastionSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, bastionInstance, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, sshdConfigPath, preferredAlgs)
           }
+          case SsmScp => (sourceFileOpt, targetFileOpt) match {
+            case (Some(sourceFile), Some(targetFile)) => setUpStandardScp(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, targetInstancePortNumberOpt, sshdConfigPath, preferredAlgs, useAgent, sourceFile, targetFile)
+            case _ => fail()
+          }
+
         }
       case Some(_) => fail()
       case None => System.exit(ArgumentsError.code) // parsing cmd line args failed, help message will have been displayed
@@ -105,6 +110,40 @@ object Main {
       targetHostKey <- Attempt.fromEither(Logic.getHostKeyEntry(targetResult, preferredAlgs))
       hostKeyFile <- SSH.writeHostKey((bastionAddress, bastionHostKey), (targetAddress, targetHostKey))
     } yield SSH.sshCmdBastion(rawOutput)(privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile))
+    val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
+    programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
+    System.exit(programResult.fold(_.exitCode, _ => 0))
+  }
+
+  private def setUpStandardScp(
+                                awsClients: AWSClients,
+                                executionTarget: ExecutionTarget,
+                                user: String,
+                                sism: SingleInstanceSelectionMode,
+                                onlyUsePrivateIP: Boolean,
+                                rawOutput: Boolean,
+                                targetInstancePortNumberOpt: Option[Int],
+                                sshdConfigPath: String,
+                                preferredAlgs: List[String],
+                                useAgent: Option[Boolean],
+                                sourceFile: String,
+                                targetFile: String) = {
+    val fProgramResult = for {
+      config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
+      sshArtifacts <- Attempt.fromEither(SSH.createKey())
+      (privateKeyFile, publicKey) = sshArtifacts
+      addPublicKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand(sshdConfigPath)
+      removePublicKeyCommand = SSH.removePublicKeyCommand(user, publicKey)
+      instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, sism))
+      _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
+      result <- IO.executeOnInstance(instance.id, config.name, addPublicKeyCommand, awsClients.ssmClient)
+      _ <- IO.executeOnInstanceAsync(instance.id, config.name, removePublicKeyCommand, awsClients.ssmClient)
+      hostKey <- Attempt.fromEither(Logic.getHostKeyEntry(result, preferredAlgs))
+      address <- Attempt.fromEither(Logic.getAddress(instance, onlyUsePrivateIP))
+      hostKeyFile <- SSH.writeHostKey((address, hostKey))
+    } yield {
+      SSH.scpCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, sourceFile, targetFile)
+    }
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
     System.exit(programResult.fold(_.exitCode, _ => 0))

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -140,10 +140,6 @@ object SSH {
   // The first file goes to the second file
   // The remote file is indicated by a colon
 
-  def removeFirstLetter(string: String): String = {
-    string.substring(1)
-  }
-
   def scpCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File], sourceFile: String, targetFile: String): (InstanceId, String) = {
 
     def isRemote(filepath: String): Boolean = {

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -169,9 +169,9 @@ object SSH {
     if (exactlyOneArgumentIsRemote(sourceFile, targetFile)) {
       val connectionString =
         if (isRemote(sourceFile)) {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress:${removeFirstLetter(sourceFile)} ${targetFile}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress:${sourceFile.stripPrefix(":")} ${targetFile}"""
         }else {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} ${sourceFile} $user@$ipAddress:${removeFirstLetter(targetFile)}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} ${sourceFile} $user@$ipAddress:${targetFile.stripPrefix(":")}"""
         }
       val cmd = if(rawOutput) {
         s"$connectionString"

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -29,7 +29,9 @@ case class Arguments(
   targetInstancePortNumber: Option[Int],
   useAgent: Option[Boolean],
   sshdConfigPath: Option[String],
-  hostKeyAlgPreference: List[String]
+  hostKeyAlgPreference: List[String],
+  sourceFile: Option[String],
+  targetFile: Option[String]
 )
 
 object Arguments {
@@ -56,7 +58,9 @@ object Arguments {
     targetInstancePortNumber = None,
     useAgent = None,
     sshdConfigPath = Some(defaultSshdConfigPath),
-    hostKeyAlgPreference = defaultHostKeyAlgPreference
+    hostKeyAlgPreference = defaultHostKeyAlgPreference,
+    sourceFile = None,
+    targetFile = None
   )
 }
 
@@ -77,6 +81,7 @@ sealed trait SsmMode
 case object SsmCmd extends SsmMode
 case object SsmRepl extends SsmMode
 case object SsmSsh extends SsmMode
+case object SsmScp extends SsmMode
 
 case class CommandResult(stdOut: String, stdErr: String)
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -208,40 +208,73 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", "/path/to/targetFile")
+        val (instanceId, _) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
         instanceId.id shouldEqual "raspberry"
       }
 
       "user command" - {
+
+        "process correctly remote server specifications" - {
+
+          "target file is remote" in {
+            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+            command should include ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          }
+          "source file is remote" in {
+            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
+            command should include ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+          }
+          "incorrect specifications in" in {
+            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
+            command should include ("Incorrect remote server specifications")
+          }
+        }
+
         "is correctly formed without port specification" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", "/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
           command should include ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", "/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
           command should include ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), Some(new File("/tmp/hostsfile")), "/path/to/sourceFile", "/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), Some(new File("/tmp/hostsfile")), "/path/to/sourceFile", ":/path/to/targetFile")
           command should include ("""scp -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(true), None, "/path/to/sourceFile", "/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(true), None, "/path/to/sourceFile", ":/path/to/targetFile")
           command should include ("""scp -o "IdentitiesOnly yes" -A -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
       }
 
       "machine command" - {
+        "process correctly remote server specifications" - {
+
+          "target file is remote" in {
+            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+            command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          }
+          "source file is remote" in {
+            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
+            command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+          }
+          "incorrect specifications in" in {
+            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
+            command should include ("Incorrect remote server specifications")
+          }
+        }
+
         "is correctly formed without port specification" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", "/path/to/targetFile")
-          command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
+          command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", "/path/to/targetFile")
+          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
           command should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
       }


### PR DESCRIPTION
This PR adds the **scp** sub command to **ssm**, for performing secure copy.

## Secure Copy

**ssm** support the **scp** sub command for the secure transfer of files and directories.

### Introduction

An example of usage is 

```
./ssm scp -p account -t app,stack,stage /path/to/file1 :/path/to/file1
``` 

Which outputs

```
# simplified version
scp -i /path/to/identity/file.tmp /path/to/file1 ubuntu@34.242.32.40:/path/to/file2;
```

Otherwise 

```
./ssm scp -p account -t app,stack,stage :/path/to/file1 /path/to/file2
```

outputs 

```
# simplified version
scp -i /path/to/identity/file.tmp ubuntu@34.242.32.40:/path/to/file1 /path/to/file2 ;
```

For the moment we only support moving files. Support for directories will come in the next PR.