### PR TITLE
Make agent default with bastions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,18 @@ Command: repl
 Run SSM in interactive/repl mode
 Command: ssh [options]
 Create and upload a temporary ssh key
-  -u, --user <value>       Connect to remote host as user (default: ubuntu)
+  -u, --user <value>       Connect to remote host as this user (default: ubuntu)
   --port <value>           Connect to remote host on this port
   --newest                 Selects the newest instance if more than one instance was specified
   --oldest                 Selects the oldest instance if more than one instance was specified
   --private                Use private IP address (must be routable via VPN Gateway)
   --raw                    Unix pipe-able ssh connection string
-  -a, --agent              Use the local ssh agent to register the private key (and do not use -i)
-  --bastion <value>        Connect through the given bastion specified by its instance id
+  -x, --execute            Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)
+  -a, --agent              Use the local ssh agent to register the private key (and do not use -i); only bastion connections
+  -A, --no-agent           Do not use the local ssh agent
+  -b, --bastion <value>    Connect through the given bastion specified by its instance id; implies -a (use agent) unless followed by -A
+  -B, --bastion-tags <value>
+                           Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A
   --bastion-port <value>   Connect through the given bastion at a given port
   --bastion-user <value>   Connect to bastion as this user (default: ubuntu)
 ```

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -111,9 +111,19 @@ object ArgumentParser {
               useAgent = true)
           })
           .text("Use the local ssh agent to register the private key (and do not use -i); only bastion connections"),
+        opt[Unit]('A', "no-agent").optional()
+          .action((_, args) => {
+            args.copy(
+              useAgent = false)
+          })
+          .text("Do not use the local ssh agent"),
         opt[String]('b', "bastion").optional()
-          .action((bastion, args) => args.copy(bastionInstance = Some(ExecutionTarget(Some(List(InstanceId(bastion))), None))))
-          .text(s"Connect through the given bastion specified by its instance id"),
+          .action((bastion, args) => {
+            args
+              .copy(bastionInstance = Some(ExecutionTarget(Some(List(InstanceId(bastion))), None)))
+              .copy(useAgent = true)
+          })
+          .text(s"Connect through the given bastion specified by its instance id; implies -a (use agent) unless followed by -A"),
         opt[String]('B', "bastion-tags").optional()
           .validate { tagsStr =>
             Logic.extractSASTags(tagsStr).map(_ => ())
@@ -122,9 +132,13 @@ object ArgumentParser {
             Logic.extractSASTags(tagsStr)
               .fold(
                 _ => args,
-                ass => args.copy(bastionInstance = Some(ExecutionTarget(None, Some(ass))))
+                ass => {
+                  args
+                    .copy(bastionInstance = Some(ExecutionTarget(None, Some(ass))))
+                    .copy(useAgent = true)
+                }
               )
-          } text(s"Connect through the given bastion identified by its tags"),
+          } text(s"Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A"),
         opt[Int]("bastion-port").optional()
           .action((bastionPortNumber, args) => args.copy(bastionPortNumber = Some(bastionPortNumber)))
           .text(s"Connect through the given bastion at a given port"),


### PR DESCRIPTION
## What does this change?

Turn on ssh-agent usage by default if a bastion is used.
Permit explicitly turning off ssh-agent.

## What is the value of this?

People using bastions will almost always want to use ssh-agent.
