### PR TITLE
Introduce flag --identity-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Create and upload a temporary ssh key
                            The location of the sshd configuration on the remote host (default: /etc/ssh/sshd_config)
   --host-key-alg-preference <value>
                            The preferred host key algorithms, can be specified multiple times - last is preferred (default: ecdsa-sha2-nistp256, ssh-rsa)
+  --identity-file          Specifies that only the identity file path should be displayed
 ```
 
 There are two mandatory configuration items.

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -149,6 +149,9 @@ object ArgumentParser {
         opt[String]("host-key-alg-preference").optional().unbounded()
           .action((alg, args) => args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference))
           .text(s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"),
+        opt[Unit]("identity-file").optional()
+          .action((_, args) => args.copy(shouldDisplayIdentityFileOnly = true))
+          .text(s"Specifies that only the identity file path should be displayed"),
         checkConfig( c =>
           if (c.isSelectionModeOldest && c.isSelectionModeNewest) failure("You cannot both specify --newest and --oldest")
           else success )

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -66,7 +66,7 @@ object Main {
       SSH.sshCmdStandard(rawOutput, shouldDisplayIdentityFileOnly, privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent)
     }
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
-    programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
+    programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput || shouldDisplayIdentityFileOnly))
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 
@@ -108,7 +108,7 @@ object Main {
       hostKeyFile <- SSH.writeHostKey((bastionAddress, bastionHostKey), (targetAddress, targetHostKey))
     } yield SSH.sshCmdBastion(rawOutput, shouldDisplayIdentityFileOnly, privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile))
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
-    programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
+    programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput || shouldDisplayIdentityFileOnly))
     System.exit(programResult.fold(_.exitCode, _ => 0))
   }
 

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -63,7 +63,7 @@ object Main {
       address <- Attempt.fromEither(Logic.getAddress(instance, onlyUsePrivateIP))
       hostKeyFile <- SSH.writeHostKey((address, hostKey))
     } yield {
-      SSH.sshCmdStandard(rawOutput, shouldDisplayIdentityFileOnly)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent)
+      SSH.sshCmdStandard(rawOutput, shouldDisplayIdentityFileOnly, privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent)
     }
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
@@ -106,7 +106,7 @@ object Main {
       bastionHostKey <- Attempt.fromEither(Logic.getHostKeyEntry(bastionResult, preferredAlgs))
       targetHostKey <- Attempt.fromEither(Logic.getHostKeyEntry(targetResult, preferredAlgs))
       hostKeyFile <- SSH.writeHostKey((bastionAddress, bastionHostKey), (targetAddress, targetHostKey))
-    } yield SSH.sshCmdBastion(rawOutput, shouldDisplayIdentityFileOnly)(privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile))
+    } yield SSH.sshCmdBastion(rawOutput, shouldDisplayIdentityFileOnly, privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile))
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     programResult.fold(UI.outputFailure, UI.sshOutput(rawOutput))
     System.exit(programResult.fold(_.exitCode, _ => 0))

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -90,7 +90,7 @@ object SSH {
        | for hostkey in $$(grep ^HostKey $sshd_config_path| cut -d' ' -f 2); do cat $${hostkey}.pub; done
      """.stripMargin
 
-  def sshCmdStandard(rawOutput: Boolean, shouldDisplayIdentityFileOnly: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], hostsFile: Option[File], useAgent: Option[Boolean]): (InstanceId, String) = {
+  def sshCmdStandard(rawOutput: Boolean, shouldDisplayIdentityFileOnly: Boolean, privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], hostsFile: Option[File], useAgent: Option[Boolean]): (InstanceId, String) = {
     val targetPortSpecifications = targetInstancePortNumberOpt match {
       case Some(portNumber) => s" -p $portNumber" // trailing space is important
       case _ => ""
@@ -117,7 +117,7 @@ object SSH {
     (instance.id, cmd)
   }
 
-  def sshCmdBastion(rawOutput: Boolean, shouldDisplayIdentityFileOnly: Boolean)(privateKeyFile: File, bastionInstance: Instance, targetInstance: Instance, targetInstanceUser: String, bastionIpAddress: String, targetIpAddress: String, bastionPortNumberOpt: Option[Int], bastionUser: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File]): (InstanceId, String) = {
+  def sshCmdBastion(rawOutput: Boolean, shouldDisplayIdentityFileOnly: Boolean, privateKeyFile: File, bastionInstance: Instance, targetInstance: Instance, targetInstanceUser: String, bastionIpAddress: String, targetIpAddress: String, bastionPortNumberOpt: Option[Int], bastionUser: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File]): (InstanceId, String) = {
     val bastionPort = bastionPortNumberOpt.getOrElse(22)
     val targetPort = targetInstancePortNumberOpt.getOrElse(22)
     val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -102,12 +102,10 @@ object SSH {
     }
     val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
     val connectionString = s"""ssh -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$targetPortSpecifications -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress"""
-    val cmd = if(rawOutput || shouldDisplayIdentityFileOnly) {
-      if (shouldDisplayIdentityFileOnly) {
-        privateKeyFile.getCanonicalFile.toString
-      }else{
-        s"$connectionString"
-      }
+    val cmd = if(shouldDisplayIdentityFileOnly){
+      privateKeyFile.getCanonicalFile.toString
+    }else if(rawOutput) {
+      s"$connectionString"
     }else{
       s"""
          | # Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:
@@ -130,12 +128,10 @@ object SSH {
     }
     val connectionString =
       s"""ssh$useAgentFragment -o "IdentitiesOnly yes" $identityFragment$hostsFileString $proxyFragment$stringFragmentTTOptions $targetInstanceUser@$targetIpAddress"""
-    val cmd = if(rawOutput || shouldDisplayIdentityFileOnly) {
-      if (shouldDisplayIdentityFileOnly) {
-        privateKeyFile.getCanonicalFile.toString
-      }else{
-        s"$connectionString"
-      }
+    val cmd = if(shouldDisplayIdentityFileOnly){
+      privateKeyFile.getCanonicalFile.toString
+    }else if(rawOutput) {
+      s"$connectionString"
     }else{
       s"""
          | # Execute the following commands within the next $sshCredentialsLifetimeSeconds seconds:

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -29,7 +29,8 @@ case class Arguments(
   targetInstancePortNumber: Option[Int],
   useAgent: Option[Boolean],
   sshdConfigPath: Option[String],
-  hostKeyAlgPreference: List[String]
+  hostKeyAlgPreference: List[String],
+  shouldDisplayIdentityFileOnly: Boolean
 )
 
 object Arguments {
@@ -56,7 +57,8 @@ object Arguments {
     targetInstancePortNumber = None,
     useAgent = None,
     sshdConfigPath = Some(defaultSshdConfigPath),
-    hostKeyAlgPreference = defaultHostKeyAlgPreference
+    hostKeyAlgPreference = defaultHostKeyAlgPreference,
+    shouldDisplayIdentityFileOnly = false
   )
 }
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -62,51 +62,51 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+        val (instanceId, _) = sshCmdStandard(false, false, file, instance, "user4", "34.1.1.10", None, None, Some(false))
         instanceId.id shouldEqual "raspberry"
       }
 
       "user command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+          val (_, command) = sshCmdStandard(false, false, file, instance, "user4", "34.1.1.10", None, None, Some(false))
           command should include ("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(false, false, file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
           command should include ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10""")
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false))
+          val (_, command) = sshCmdStandard(false, false, file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false))
           command should include ("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10""")
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true))
+          val (_, command) = sshCmdStandard(false, false, file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true))
           command should include ("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10""")
         }
       }
 
       "machine command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(true, false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+          val (_, command) = sshCmdStandard(true, false, file, instance, "user4", "34.1.1.10", None, None, Some(false))
           command should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(true, false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(true, false, file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
           command should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
         }
       }
 
       "identity file only display" - {
         "raw output is true" in {
-          val (_, command) = sshCmdStandard(true, true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(true, true, file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
           command should equal ("/banana")
         }
         "raw output is false" in {
-          val (_, command) = sshCmdStandard(false, true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(false, true, file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
           command should equal ("/banana")
         }
       }
@@ -120,18 +120,18 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val targetInstance = Instance(InstanceId("strawberry"), None, Some("34.1.1.11"), "10.1.1.11", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdBastion(false, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+        val (instanceId, _) = sshCmdBastion(false, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
         instanceId.id shouldEqual "strawberry"
       }
 
       "user command" - {
         "contains the user instructions" in {
-          val (_, command) = sshCmdBastion(false, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          val (_, command) = sshCmdBastion(false, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
           command should include (s"# Execute the following commands within the next $sshCredentialsLifetimeSeconds seconds")
         }
 
         "contains the ssh command" in {
-          val (_, command) = sshCmdBastion(false, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          val (_, command) = sshCmdBastion(false, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
           command should include ("ssh")
         }
       }
@@ -139,83 +139,83 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       "machine command" - {
         "is well formed without any port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, None, None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "no agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(true), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with target instance port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), None, None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
           "no agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(false), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(true), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with bastion port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, None, None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
           "no agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(false), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(true), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with both bastion port and target instance port specifications" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), None, None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "no agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(true), None)
+            val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with a host key file" in {
-          val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), Some(new File("/tmp/hostfile")))
+          val (_, command) = sshCmdBastion(true, false, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), Some(new File("/tmp/hostfile")))
           command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
         }
       }
 
       "identity file only display" - {
         "raw output is true" in {
-          val (_, command) = sshCmdBastion(true, true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          val (_, command) = sshCmdBastion(true, true, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
           command should equal ("/banana")
         }
         "raw output is false" in {
-          val (_, command) = sshCmdBastion(false, true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          val (_, command) = sshCmdBastion(false, true, file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
           command should equal ("/banana")
         }
       }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -62,43 +62,55 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+        val (instanceId, _) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
         instanceId.id shouldEqual "raspberry"
       }
 
       "user command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
           command should include ("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
           command should include ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10""")
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false))
+          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false))
           command should include ("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10""")
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true))
+          val (_, command) = sshCmdStandard(false, false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true))
           command should include ("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10""")
         }
       }
 
       "machine command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+          val (_, command) = sshCmdStandard(true, false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
           command should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(true, false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
           command should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
         }
       }
+
+      "identity file only display" - {
+        "raw output is true" in {
+          val (_, command) = sshCmdStandard(true, true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          command should equal ("/banana")
+        }
+        "raw output is false" in {
+          val (_, command) = sshCmdStandard(false, true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          command should equal ("/banana")
+        }
+      }
+
     }
 
     "create bastion ssh command" - {
@@ -108,18 +120,18 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val targetInstance = Instance(InstanceId("strawberry"), None, Some("34.1.1.11"), "10.1.1.11", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+        val (instanceId, _) = sshCmdBastion(false, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
         instanceId.id shouldEqual "strawberry"
       }
 
       "user command" - {
         "contains the user instructions" in {
-          val (_, command) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          val (_, command) = sshCmdBastion(false, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
           command should include (s"# Execute the following commands within the next $sshCredentialsLifetimeSeconds seconds")
         }
 
         "contains the ssh command" in {
-          val (_, command) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          val (_, command) = sshCmdBastion(false, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
           command should include ("ssh")
         }
       }
@@ -127,75 +139,87 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       "machine command" - {
         "is well formed without any port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, None, None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(true), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with target instance port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), None, None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(false), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(true), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with bastion port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, None, None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(false), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(true), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with both bastion port and target instance port specifications" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), None, None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), None, None)
             command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), None)
             command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(true), None)
+            val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(true), None)
             command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with a host key file" in {
-          val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), Some(new File("/tmp/hostfile")))
+          val (_, command) = sshCmdBastion(true, false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), Some(new File("/tmp/hostfile")))
           command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
         }
       }
+
+      "identity file only display" - {
+        "raw output is true" in {
+          val (_, command) = sshCmdBastion(true, true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          command should equal ("/banana")
+        }
+        "raw output is false" in {
+          val (_, command) = sshCmdBastion(false, true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+          command should equal ("/banana")
+        }
+      }
+
     }
   }
 }


### PR DESCRIPTION
## What does this change?
Introduce flag `--identity-file` causing only the identity file path to be displayed (for use in scripts)

## What is the value of this?
Allow custom shell scripts built around ssm to be much more robust.