### PR TITLE
Improve the documentation for the --raw option

### DIFF
--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -98,7 +98,7 @@ object ArgumentParser {
             args.copy(
               rawOutput = true)
           })
-          .text("Unix pipe-able ssh connection string"),
+          .text("Unix pipe-able ssh connection string - note: you must use 'eval' to execute this due to nested quoting"),
         opt[Unit]('x', "execute").optional()
           .action((_, args) => {
             args.copy(


### PR DESCRIPTION
## What does this change?
My recent changes to SSM in #84 made liberal use of quotes when specifying options (particularly around `ProxyCommand` for bastion access). This breaks `--raw` if you execute it directly as bash will interpret `ssh -o "IdentitiesOnly yes"` as four separate terms: `ssh`, `-o`, `"IdentitiesOnly` and `yes"`. By using `eval` it ensures that it is evaluated as if it had been typed into a terminal directly.

This is therefore a documentation change that advises people to use eval in combination with `--raw`

## What is the value of this?
People were getting an error when using `--raw`. This documents how it can be used.

## Any additional notes?
No