### PR TITLE
Moving user's temporary files to OS's temp folder

### DIFF
--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -20,7 +20,7 @@ object SSH {
     val keyProvider = "BC"
 
     try {
-      val privateKeyFile = File.createTempFile(prefix, suffix)
+      val privateKeyFile = File.createTempFile(prefix, suffix, new File(System.getProperty("java.io.tmpdir")))
       FilePermissions(privateKeyFile, "0600")
       val publicKey = KeyMaker.makeKey(privateKeyFile, keyAlgorithm, keyProvider)
       Right((privateKeyFile, publicKey))


### PR DESCRIPTION
The temporary files generated by ssm are not automatically cleaned up, so we are moving them to the OS's temp folder.
