### PR TITLE
Move IO right to the edge, allow flexible output and add --verbose flag

### DIFF
--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -47,6 +47,9 @@ object ArgumentParser {
       args.copy(region = Region.getRegion(Regions.fromName(region)))
     } text "AWS region name (defaults to eu-west-1)"
 
+    opt[Unit]("verbose").action( (_, c) =>
+      c.copy(verbose = true) ).text("enable more verbose logging")
+
     cmd("cmd")
       .action((_, c) => c.copy(mode = Some(SsmCmd)))
       .text("Execute a single (bash) command, or a file containing bash commands")

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -1,42 +1,102 @@
 package com.gu.ssm
 
-import com.gu.ssm.utils.attempt.FailedAttempt
+import java.io.{ByteArrayOutputStream, PrintWriter}
 
+import com.gu.ssm.utils.attempt.{ExitCode, FailedAttempt}
+
+import scala.collection.mutable
+
+sealed trait Output {
+  def text: String
+  def newline: Boolean = true
+}
+case class Out(text: String, override val newline: Boolean = true) extends Output
+case class Metadata(text: String) extends Output
+case class Err(text: String, throwable: Option[Throwable] = None) extends Output
+case class Verbose(text: String) extends Output
+
+case class ProgramResult(output: Seq[Output], nonZeroExitCode: Option[ExitCode] = None)
+object ProgramResult {
+  def apply(result: Either[FailedAttempt, Seq[Output]]): ProgramResult = {
+    result.fold[ProgramResult] (
+      failedAttempt => ProgramResult.apply(UI.outputFailure(failedAttempt), Some(failedAttempt.exitCode)),
+      output => ProgramResult.apply(output, None)
+    )
+  }
+}
 
 object UI {
-  def output(extendedResults: ResultsWithInstancesNotFound): Unit = {
-    if(extendedResults.instancesNotFound.nonEmpty){
-      UI.printErr(s"The following instance(s) could not be found: ${extendedResults.instancesNotFound.map(_.id).mkString(", ")}\n")
+  implicit class RichString(val s: String) extends AnyVal {
+    def colour(colour: String): String = {
+      colour + s + Console.RESET
     }
-    extendedResults.results.foreach { case (instance, result) =>
-      UI.printMetadata(s"========= ${instance.id} =========")
+  }
+  implicit class RichThrowable(val t: Throwable) extends AnyVal {
+    def getAsString: String = {
+      val baos = new ByteArrayOutputStream()
+      val pw = new PrintWriter(baos)
+      t.printStackTrace(pw)
+      pw.close()
+      baos.toString
+    }
+  }
+
+  def output(extendedResults: ResultsWithInstancesNotFound): Seq[Output] = {
+    val buffer = mutable.Buffer.empty[Output]
+    if(extendedResults.instancesNotFound.nonEmpty){
+      buffer += Err(s"The following instance(s) could not be found: ${extendedResults.instancesNotFound.map(_.id).mkString(", ")}\n")
+    }
+    extendedResults.results.flatMap { case (instance, result) =>
+      buffer += Metadata(s"========= ${instance.id} =========")
       if (result.isLeft) {
-        UI.printErr(result.left.get.toString)
+        buffer += Err(result.left.get.toString)
       } else {
         val output = result.right.get
-        UI.printMetadata(s"STDOUT:")
-        println(output.stdOut)
-        UI.printMetadata(s"STDERR:")
-        UI.printErr(output.stdErr)
+        buffer ++= Seq(
+          Metadata(s"STDOUT:"),
+          Out(output.stdOut),
+          Metadata(s"STDERR:"),
+          Err(output.stdErr)
+        )
       }
     }
+    buffer.toList
   }
 
-  def sshOutput(rawOutput: Boolean)(result: (InstanceId, String)): Unit = {
+  def sshOutput(rawOutput: Boolean)(result: (InstanceId, Seq[Output])): Seq[Output] = {
     if (rawOutput){
-      Thread.sleep(1000)
-      print(result._2)
+      result._2
     } else {
-      UI.printMetadata(s"========= ${result._1.id} =========")
-      UI.printMetadata(s"STDOUT:")
-      println(result._2)
+      Metadata(s"========= ${result._1.id} =========") +: result._2
     }
   }
 
-  def outputFailure(failedAttempt: FailedAttempt): Unit = {
-    failedAttempt.failures.foreach { failure =>
-      printErr(failure.friendlyMessage)
+  def outputFailure(failedAttempt: FailedAttempt): Seq[Output] = {
+    failedAttempt.failures.flatMap { failure =>
+      Seq(Err(failure.friendlyMessage, failure.throwable)) ++ failure.context.map(Verbose.apply)
     }
+  }
+}
+
+class UI(verbose: Boolean) {
+  import UI._
+
+  def printAll(output: Seq[Output]): Unit = print(output: _*)
+
+  def print(output: Output*): Unit = {
+    output.foreach {
+      case Out(text, true) => System.out.println(text)
+      case Out(text, false) => System.out.print(text)
+      case Metadata(text) => printMetadata(text)
+      case Err(text, maybeThrowable) =>
+        printErr(text)
+        maybeThrowable.foreach { t => printVerbose(t.getAsString) }
+      case Verbose(text) => printVerbose(text)
+    }
+  }
+
+  def printVerbose(text: String): Unit = {
+    if (verbose) System.err.println(text.colour(Console.BLUE))
   }
 
   def printMetadata(text: String): Unit = {
@@ -47,9 +107,4 @@ object UI {
     System.err.println(text.colour(Console.YELLOW))
   }
 
-  implicit class RichString(val s: String) extends AnyVal {
-    def colour(colour: String): String = {
-      colour + s + Console.RESET
-    }
-  }
 }

--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -26,16 +26,16 @@ object AwsAsyncHandler {
         case _ => None
       }
       if (e.getMessage.contains("Request has expired")) {
-        Failure("expired AWS credentials", "Failed to request data from AWS, the temporary credentials have expired", AwsPermissionsError).attempt
+        Failure("expired AWS credentials", "Failed to request data from AWS, the temporary credentials have expired", AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
-        Failure("Invalid AWS profile name (no credentials)", "No credentials found for the specified AWS profile", AwsPermissionsError).attempt
+        Failure("Invalid AWS profile name (no credentials)", "No credentials found for the specified AWS profile", AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("No AWS profile named")) {
-        Failure("Invalid AWS profile name (does not exist)", "The specified AWS profile does not exist", AwsPermissionsError).attempt
+        Failure("Invalid AWS profile name (does not exist)", "The specified AWS profile does not exist", AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("is not authorized to perform")) {
         val message = serviceNameOpt.fold("You do not have sufficient AWS privileges")(serviceName => s"You do not have sufficient privileges to perform actions on $serviceName")
-        Failure("insufficient permissions", message, AwsPermissionsError).attempt
+        Failure("insufficient permissions", message, AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("InvalidInstanceId")) {
-        Failure("InvalidInstanceId from AWS", "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)", AwsError).attempt
+        Failure("InvalidInstanceId from AWS", "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)", AwsError, e).attempt
       } else {
         val details = serviceNameOpt.fold("AWS unknown error, unknown service (check logs for stacktrace)") { serviceName =>
           s"AWS unknown error, service: $serviceName (check logs for stacktrace), ${e.getMessage}"
@@ -43,7 +43,7 @@ object AwsAsyncHandler {
         val friendlyMessage = serviceNameOpt.fold("Unknown error while making API calls to AWS.") { serviceName =>
           s"Unknown error while making an API call to AWS' $serviceName service, ${e.getMessage}"
         }
-        Failure(details, friendlyMessage, AwsError).attempt
+        Failure(details, friendlyMessage, AwsError, e).attempt
       }
     }
   }

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -12,6 +12,7 @@ case class AppStackStage(app: String, stack: String, stage: String)
 case class ExecutionTarget(instances: Option[List[InstanceId]] = None, ass: Option[AppStackStage] = None)
 
 case class Arguments(
+  verbose: Boolean,
   executionTarget: Option[ExecutionTarget],
   toExecute: Option[String],
   profile: Option[String],
@@ -41,6 +42,7 @@ object Arguments {
   val defaultHostKeyAlgPreference = List("ecdsa-sha2-nistp256", "ssh-rsa")
 
   def empty(): Arguments = Arguments(
+    verbose = false,
     executionTarget = None,
     toExecute = None,
     profile = None,

--- a/src/main/scala/com/gu/ssm/utils/attempt/Attempt.scala
+++ b/src/main/scala/com/gu/ssm/utils/attempt/Attempt.scala
@@ -56,7 +56,7 @@ case class Attempt[A] private (underlying: Future[Either[FailedAttempt, A]]) {
     */
   def asFuture(implicit ec: ExecutionContext): Future[Either[FailedAttempt, A]] = {
     underlying recover { case err =>
-      val apiErrors = FailedAttempt(Failure(err.getMessage, "Unexpected error", UnhandledError, throwable = Some(err)))
+      val apiErrors = FailedAttempt(Failure(err.getMessage, "Unexpected error", UnhandledError, err))
       scala.Left(apiErrors)
     }
   }
@@ -165,7 +165,7 @@ object Attempt {
     }
     timer.schedule(unitTask, delay.toMillis)
     Attempt.fromFuture(prom.future) {
-      case NonFatal(e) => Failure("failed to run delay task", "Internal error while delaying operations", ErrorCode, throwable = Some(e)).attempt
+      case NonFatal(e) => Failure("failed to run delay task", "Internal error while delaying operations", ErrorCode, e).attempt
     }
   }
 

--- a/src/main/scala/com/gu/ssm/utils/attempt/Failure.scala
+++ b/src/main/scala/com/gu/ssm/utils/attempt/Failure.scala
@@ -2,7 +2,7 @@ package com.gu.ssm.utils.attempt
 
 
 case class FailedAttempt(failures: List[Failure]) {
-  def exitCode: Int = failures.map(_.exitCode.code).max
+  def exitCode: ExitCode = failures.map(_.exitCode).maxBy(_.code)
 }
 
 object FailedAttempt {
@@ -22,6 +22,24 @@ case class Failure(
   throwable: Option[Throwable] = None
 ) {
   def attempt = FailedAttempt(this)
+}
+object Failure {
+  def apply(message: String,
+            friendlyMessage: String,
+            exitCode: ExitCode): Failure = apply(message, friendlyMessage, exitCode, None, None)
+  def apply(message: String,
+            friendlyMessage: String,
+            exitCode: ExitCode,
+            context: String): Failure = apply(message, friendlyMessage, exitCode, Some(context), None)
+  def apply(message: String,
+            friendlyMessage: String,
+            exitCode: ExitCode,
+            throwable: Throwable): Failure = apply(message, friendlyMessage, exitCode, None, Some(throwable))
+  def apply(message: String,
+            friendlyMessage: String,
+            exitCode: ExitCode,
+            context: String,
+            throwable: Throwable): Failure = apply(message, friendlyMessage, exitCode, Some(context), Some(throwable))
 }
 
 sealed abstract class ExitCode(val code: Int)

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -69,34 +69,34 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       "user command" - {
         "is correctly formed without port specification" in {
           val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
-          command should include ("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10""")
+          command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with port specification" in {
           val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
-          command should include ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10""")
+          command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with a hosts file" in {
           val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false))
-          command should include ("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10""")
+          command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with agent forwarding file" in {
           val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true))
-          command should include ("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10""")
+          command should contain (Out("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10;"""))
         }
       }
 
       "machine command" - {
         "is correctly formed without port specification" in {
           val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
-          command should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
+          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
           val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
-          command should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
+          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
         }
       }
     }
@@ -115,12 +115,12 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       "user command" - {
         "contains the user instructions" in {
           val (_, command) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
-          command should include (s"# Execute the following commands within the next $sshCredentialsLifetimeSeconds seconds")
+          command should contain (Metadata(s"# Execute the following command within the next $sshCredentialsLifetimeSeconds seconds:"))
         }
 
         "contains the ssh command" in {
           val (_, command) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
-          command should include ("ssh")
+          command.find(_.isInstanceOf[Out]).head.text should include ("ssh")
         }
       }
 
@@ -128,72 +128,72 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
         "is well formed without any port specification" - {
           "agent-agnostic" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, None, None)
-            command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "no agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
-            command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(true), None)
-            command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with target instance port specification" - {
           "agent-agnostic" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), None, None)
-            command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
           "no agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(false), None)
-            command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(true), None)
-            command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with bastion port specification" - {
           "agent-agnostic" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, None, None)
-            command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
           "no agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(false), None)
-            command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(true), None)
-            command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with both bastion port and target instance port specifications" - {
           "agent-agnostic" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), None, None)
-            command should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "no agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), None)
-            command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
 
           "with agent" in {
             val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(true), None)
-            command should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
           }
         }
 
         "is well formed with a host key file" in {
           val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), Some(new File("/tmp/hostfile")))
-          command should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+          command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
         }
       }
     }
@@ -218,36 +218,36 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "target file is remote" in {
             val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-            command should include ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+            command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
           }
           "source file is remote" in {
             val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
-            command should include ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+            command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile;"""))
           }
           "incorrect specifications in" in {
             val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
-            command should include ("Incorrect remote server specifications")
+            command.head.text should include ("Incorrect remote server specifications")
           }
         }
 
         "is correctly formed without port specification" in {
           val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-          command should include ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
 
         "is correctly formed with port specification" in {
           val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-          command should include ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          command should contain (Out("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
 
         "is correctly formed with a hosts file" in {
           val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), Some(new File("/tmp/hostsfile")), "/path/to/sourceFile", ":/path/to/targetFile")
-          command should include ("""scp -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          command should contain (Out("""scp -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
 
         "is correctly formed with agent forwarding file" in {
           val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(true), None, "/path/to/sourceFile", ":/path/to/targetFile")
-          command should include ("""scp -o "IdentitiesOnly yes" -A -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          command should contain (Out("""scp -o "IdentitiesOnly yes" -A -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
       }
 
@@ -256,26 +256,26 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "target file is remote" in {
             val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-            command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
           }
           "source file is remote" in {
             val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
-            command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
           }
           "incorrect specifications in" in {
             val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
-            command should include ("Incorrect remote server specifications")
+            command.head.text should include ("Incorrect remote server specifications")
           }
         }
 
         "is correctly formed without port specification" in {
           val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
-          command should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
         }
 
         "is correctly formed with port specification" in {
           val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-          command should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
       }
     }


### PR DESCRIPTION
This replaces the string output type with various output types that can be processed by the UI classes. By allowing this to be returned by the actual methods we grant much greater flexibility in how output is presented (and can be optionally presented using the new `--verbose` flag).