### PR TITLE
Remove suggestion to use AmazonEC2RoleforSSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,15 +360,7 @@ To use ssm-scala against the instances of your project, three things need to hap
 
 1. Update your base image in AMIgo with the **ssm-agent** role.
 
-2. Add the following declaration 
-
-	```
-	ManagedPolicyArns: [ "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM" ]
-	```
-
-	under the `AWS::IAM::Role`'s `Properties` to your cloudformation. 
-	
-	Alternatively, considering that this policy might not work for instances requiring limited set of permissions, you can add (an adaptation of) the following `AWS::IAM::Policy` to your cloudformation file
+2. Add permissions with a policy like:
 	
 	```
 	  ExampleAppSSMRunCommandPolicy:


### PR DESCRIPTION
AmazonEC2RoleforSSM is way too permissive and it's not immediately clear of the extent to which this is the case, so very easy for a developer to use it.

## What does this change?
Removes the suggestion to use AmazonEC2RoleforSSM
<!-- Screenshots may be helpful to demonstrate -->



## What is the value of this?
AmazonEC2RoleforSSM is a very permissive policy that can easily expose access to s3 every bucket unnecessarily.


## Any additional notes?