### PR TITLE
Fix "output host keys" remote command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Create and upload a temporary ssh key
                            Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A
   --bastion-port <value>   Connect through the given bastion at a given port
   --bastion-user <value>   Connect to bastion as this user (default: ubuntu)
-  --sshd-config-path <value>
-                           The location of the sshd configuration on the remote host (default: /etc/ssh/sshd_config)
   --host-key-alg-preference <value>
                            The preferred host key algorithms, can be specified multiple times - last is preferred (default: ecdsa-sha2-nistp256, ssh-rsa)
 Command: scp [options] <sourceFile>... <targetFile>...

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -3,7 +3,7 @@ package com.gu.ssm
 import java.io.File
 
 import com.amazonaws.regions.{Region, Regions}
-import com.gu.ssm.Arguments.{targetInstanceDefaultUser, bastionDefaultUser, defaultSshdConfigPath, defaultHostKeyAlgPreference}
+import com.gu.ssm.Arguments.{targetInstanceDefaultUser, bastionDefaultUser, defaultHostKeyAlgPreference}
 import scopt.OptionParser
 
 
@@ -146,9 +146,6 @@ object ArgumentParser {
         opt[String]("bastion-user").optional()
           .action((bastionUser, args) => args.copy(bastionUser = Some(bastionUser)))
           .text(s"Connect to bastion as this user (default: $bastionDefaultUser)"),
-        opt[String]("sshd-config-path").optional()
-          .action((sshdConfigPath, args) => args.copy(sshdConfigPath = Some(sshdConfigPath)))
-          .text(s"The location of the sshd configuration on the remote host (default: $defaultSshdConfigPath)"),
         opt[String]("host-key-alg-preference").optional().unbounded()
           .action((alg, args) => args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference))
           .text(s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"),

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -85,9 +85,9 @@ object SSH {
       | /bin/sed -i '/${publicKey.replaceAll("/", "\\\\/")}/d' /home/$user/.ssh/authorized_keys;
       |""".stripMargin
 
-  def outputHostKeysCommand(sshd_config_path: String): String =
-    s"""
-       | for hostkey in $$(grep ^HostKey $sshd_config_path| cut -d' ' -f 2); do cat $${hostkey}.pub; done
+  def outputHostKeysCommand(): String =
+    """
+       | for hostkey in $(sshd -T 2> /dev/null |grep "^hostkey " | cut -d ' ' -f 2); do cat $hostkey.pub; done
      """.stripMargin
 
   def sshCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], hostsFile: Option[File], useAgent: Option[Boolean]): (InstanceId, Seq[Output]) = {

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -29,7 +29,6 @@ case class Arguments(
   bastionUser: Option[String],
   targetInstancePortNumber: Option[Int],
   useAgent: Option[Boolean],
-  sshdConfigPath: Option[String],
   hostKeyAlgPreference: List[String],
   sourceFile: Option[String],
   targetFile: Option[String]
@@ -38,7 +37,6 @@ case class Arguments(
 object Arguments {
   val targetInstanceDefaultUser = "ubuntu"
   val bastionDefaultUser = "ubuntu"
-  val defaultSshdConfigPath = "/etc/ssh/sshd_config"
   val defaultHostKeyAlgPreference = List("ecdsa-sha2-nistp256", "ssh-rsa")
 
   def empty(): Arguments = Arguments(
@@ -59,7 +57,6 @@ object Arguments {
     bastionUser = Some(bastionDefaultUser),
     targetInstancePortNumber = None,
     useAgent = None,
-    sshdConfigPath = Some(defaultSshdConfigPath),
     hostKeyAlgPreference = defaultHostKeyAlgPreference,
     sourceFile = None,
     targetFile = None


### PR DESCRIPTION
**EDIT** I spoke to Simon and now it's loads better

## What does this change?

Fixes SSM's ssh for connecting to instances running Ubuntu 18.04.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Bug fix! At the moment SSM is unusable for instances that use Ubuntu Bionic (18.04) as their base image.

## Any additional notes?

We now query `sshd` directly rather than parsing the config files. This is simpler and loads more robust.