### PR TITLE
Remove -t options for the scp subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Create and upload a temporary ssh key
   --bastion-user <value>   Connect to bastion as this user (default: ubuntu)
   --host-key-alg-preference <value>
                            The preferred host key algorithms, can be specified multiple times - last is preferred (default: ecdsa-sha2-nistp256, ssh-rsa)
-Command: scp [options] <sourceFile>... <targetFile>...
+Command: scp [options] [:]<sourceFile>... [:]<targetFile>...
 Secure Copy
   -u, --user <value>       Connect to remote host as this user (default: ubuntu)
   --port <value>           Connect to remote host on this port

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -196,10 +196,10 @@ object ArgumentParser {
               rawOutput = true)
           })
           .text("Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"),
-        arg[String]("<sourceFile>...").required()
+        arg[String]("[:]<sourceFile>...").required()
           .action( (sourceFile, args) => args.copy(sourceFile = Some(sourceFile)) )
           .text("Source file for the scp sub command. See README for details"),
-        arg[String]("<targetFile>...").required()
+        arg[String]("[:]<targetFile>...").required()
           .action( (targetFile, args) => args.copy(targetFile = Some(targetFile)) )
           .text("Target file for the scp sub command. See README for details"),
         checkConfig( c =>

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -155,7 +155,6 @@ object SSH {
       case _ => ""
     }
     val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
-    val theTTOptions = if(rawOutput) { " -t -t" }else{ "" }
     val useAgentFragment = useAgent match {
       case None => ""
       case Some(decision) => if(decision) " -A" else " -a"
@@ -165,9 +164,9 @@ object SSH {
     if (exactlyOneArgumentIsRemote(sourceFile, targetFile)) {
       val connectionString =
         if (isRemote(sourceFile)) {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress:${sourceFile.stripPrefix(":")} ${targetFile}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} $user@$ipAddress:${sourceFile.stripPrefix(":")} ${targetFile}"""
         }else {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} ${sourceFile} $user@$ipAddress:${targetFile.stripPrefix(":")}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} ${sourceFile} $user@$ipAddress:${targetFile.stripPrefix(":")}"""
         }
       val cmd = if(rawOutput) {
         Seq(Out(s"$connectionString", newline = false))

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -256,11 +256,11 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
           "target file is remote" in {
             val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
           }
           "source file is remote" in {
             val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
-            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
           }
           "incorrect specifications in" in {
             val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
@@ -270,12 +270,12 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
 
         "is correctly formed without port specification" in {
           val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
-          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
         }
 
         "is correctly formed with port specification" in {
           val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
-          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
       }
     }


### PR DESCRIPTION
## What does this change?

Corrects the problem reported here: https://github.com/guardian/ssm-scala/issues/105

The `-t` option is not actually a `scp` option and its occurrence in the output string of the `scp` subcommands was a vestige of `ssh`.
