### PR TITLE
Add support for -u option in `ssm cmd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Usage: ssm [cmd|repl|ssh|scp] [options] <args>...
   -r, --region <value>     AWS region name (defaults to eu-west-1)
 Command: cmd [options]
 Execute a single (bash) command, or a file containing bash commands
+  -u, --user <value>       Execute the command on the remote host as this user (default: ubuntu)
   -c, --cmd <value>        A bash command to execute
   -f, --file <value>       A file containing bash commands to execute
 Command: repl

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -54,6 +54,9 @@ object ArgumentParser {
       .action((_, c) => c.copy(mode = Some(SsmCmd)))
       .text("Execute a single (bash) command, or a file containing bash commands")
       .children(
+        opt[String]('u', "user").optional()
+          .action((user, args) => args.copy(targetInstanceUser = Some(user)))
+          .text(s"Execute command on remote host as this user (default: $targetInstanceDefaultUser)"),
         opt[String]('c', "cmd").optional()
           .action((cmd, args) => args.copy(toExecute = Some(cmd)))
           .text("A bash command to execute"),


### PR DESCRIPTION
## What does this change?

It is sometimes necessary to execute remote bash commands as another user, e.g. when the bash script is in that user's home folder, but also to make sure proper permissions are set on generated files etc.

## What is the value of this?

The `-u` option is already available for `ssm ssh`, applying it to others seems to follow naturally.