### PR TITLE
Optionally tunnel SSH through Systems Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Usage: ssm [cmd|repl|ssh|scp] [options] <args>...
   -i, --instances <value>  Specify the instance ID(s) on which the specified command(s) should execute
   -t, --tags <value>       Search for instances by tag e.g. '--tags app,stack,stage'
   -r, --region <value>     AWS region name (defaults to eu-west-1)
+  --verbose                enable more verbose logging
 Command: cmd [options]
 Execute a single (bash) command, or a file containing bash commands
-  -u, --user <value>       Execute the command on the remote host as this user (default: ubuntu)
+  -u, --user <value>       Execute command on remote host as this user (default: ubuntu)
   -c, --cmd <value>        A bash command to execute
   -f, --file <value>       A file containing bash commands to execute
 Command: repl
@@ -61,13 +62,14 @@ Create and upload a temporary ssh key
   -x, --execute            Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)
   -A, --agent              Use the local ssh agent to register the private key (and do not use -i); only bastion connections
   -a, --no-agent           Do not use the local ssh agent
-  -b, --bastion <value>    Connect through the given bastion specified by its instance id; implies -A (use agent) unless followed by -a
+  -b, --bastion <value>    Connect through the given bastion specified by its instance id; implies -A (use agent) unless followed by -a. --ssm-tunnel can be used to avoid the need for a bastion instance
   -B, --bastion-tags <value>
-                           Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A
-  --bastion-port <value>   Connect through the given bastion at a given port
-  --bastion-user <value>   Connect to bastion as this user (default: ubuntu)
+                           Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A. --ssm-tunnel can be used to avoid the need for a bastion instance
+  --bastion-port <value>   Connect through the given bastion at a given port. --ssm-tunnel can be used to avoid the need for a bastion instance
+  --bastion-user <value>   Connect to bastion as this user (default: ubuntu). --ssm-tunnel can be used to avoid the need for a bastion instance
   --host-key-alg-preference <value>
                            The preferred host key algorithms, can be specified multiple times - last is preferred (default: ecdsa-sha2-nistp256, ssh-rsa)
+  --ssm-tunnel             Connect to the host proxying through AWS Systems Manager, rather than directly to port 22. Requires Systems Manager Agent > 2.3.672.0 to be installed.
 Command: scp [options] [:]<sourceFile>... [:]<targetFile>...
 Secure Copy
   -u, --user <value>       Connect to remote host as this user (default: ubuntu)
@@ -77,8 +79,8 @@ Secure Copy
   --private                Use private IP address (must be routable via VPN Gateway)
   --raw                    Unix pipe-able scp connection string
   -x, --execute            Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)
-  <sourceFile>...          Source file for the scp sub command. See README for details
-  <targetFile>...          Target file for the scp sub command. See README for details
+  [:]<sourceFile>...       Source file for the scp sub command. See README for details
+  [:]<targetFile>...       Target file for the scp sub command. See README for details
 ```
 
 There are two mandatory configuration items.
@@ -204,9 +206,18 @@ instead of the example given in the previous `--raw` section.
 
 ## Bastions
 
-### Introduction
+Bastion are proxy servers used as entry point to private networks and ssm scala supports their use.
 
-Bastion are proxy servers used as entry point to private networks and ssm scala supports their use. 
+You may not need a bastion server at all! The latest version of the AWS Systems Manager (> 2.3.672.0) supports proxying
+connections to instances via the Systems Manager service:
+
+```
+ssm ssh --profile <profile-name> -i i-application-12345 --ssm-tunnel
+```
+
+This runs entirely internal to AWS, meaning you can close off port 22 access to external networks.
+
+### Introduction
 
 In this example we assume that you have a bastion with a public IP address (even though the bastion Ingress rules may restrict it to some IP ranges), identified by aws instance id `i-bastion12345`, and an application server, on a private network with private IP address, and with instance id `i-application-12345`, you would then use ssm to connect to it using 
 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -128,7 +128,7 @@ object ArgumentParser {
             args
               .copy(bastionInstance = Some(ExecutionTarget(Some(List(InstanceId(bastion))), None)))
           })
-          .text(s"Connect through the given bastion specified by its instance id; implies -A (use agent) unless followed by -a"),
+          .text(s"Connect through the given bastion specified by its instance id; implies -A (use agent) unless followed by -a. --ssm-tunnel can be used to avoid the need for a bastion instance"),
         opt[String]('B', "bastion-tags").optional()
           .validate { tagsStr =>
             Logic.extractSASTags(tagsStr).map(_ => ())
@@ -142,13 +142,13 @@ object ArgumentParser {
                     .copy(bastionInstance = Some(ExecutionTarget(None, Some(ass))))
                 }
               )
-          } text(s"Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A"),
+          } text(s"Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A. --ssm-tunnel can be used to avoid the need for a bastion instance"),
         opt[Int]("bastion-port").optional()
           .action((bastionPortNumber, args) => args.copy(bastionPortNumber = Some(bastionPortNumber)))
-          .text(s"Connect through the given bastion at a given port"),
+          .text(s"Connect through the given bastion at a given port. --ssm-tunnel can be used to avoid the need for a bastion instance"),
         opt[String]("bastion-user").optional()
           .action((bastionUser, args) => args.copy(bastionUser = Some(bastionUser)))
-          .text(s"Connect to bastion as this user (default: $bastionDefaultUser)"),
+          .text(s"Connect to bastion as this user (default: $bastionDefaultUser). --ssm-tunnel can be used to avoid the need for a bastion instance"),
         opt[String]("host-key-alg-preference").optional().unbounded()
           .action((alg, args) => args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference))
           .text(s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"),

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -152,6 +152,11 @@ object ArgumentParser {
         opt[String]("host-key-alg-preference").optional().unbounded()
           .action((alg, args) => args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference))
           .text(s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"),
+
+        opt[Unit]("ssm-tunnel").optional()
+          .action((_, args) => args.copy(tunnelThroughSystemsManager = true))
+          .text("Connect to the host proxying through AWS Systems Manager, rather than directly to port 22. Requires Systems Manager Agent > 2.3.672.0 to be installed."),
+
         checkConfig( c =>
           if (c.isSelectionModeOldest && c.isSelectionModeNewest) failure("You cannot both specify --newest and --oldest")
           else success )

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -13,7 +13,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val (result, verbose) = argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt)) =>
+      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt, tunnelThroughSystemsManager)) =>
         val awsClients = Logic.getClients(profile, region)
         val r = mode match {
           case SsmRepl =>
@@ -25,7 +25,7 @@ object Main {
               case _ => fail
             }
           case SsmSsh => bastionInstanceIdOpt match {
-            case None => setUpStandardSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, targetInstancePortNumberOpt, preferredAlgs, useAgent, profile, region)
+            case None => setUpStandardSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, targetInstancePortNumberOpt, preferredAlgs, useAgent, profile, region, tunnelThroughSystemsManager)
             case Some(bastionInstance) => setUpBastionSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, bastionInstance, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, preferredAlgs)
           }
           case SsmScp => (sourceFileOpt, targetFileOpt) match {
@@ -58,7 +58,8 @@ object Main {
     preferredAlgs: List[String],
     useAgent: Option[Boolean],
     profile: Option[String],
-    region: Region) = {
+    region: Region,
+    tunnelThroughSystemsManager: Boolean) = {
     val fProgramResult = for {
       config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
@@ -73,7 +74,7 @@ object Main {
       address <- Attempt.fromEither(Logic.getAddress(instance, onlyUsePrivateIP))
       hostKeyFile <- SSH.writeHostKey((address, hostKey))
     } yield {
-      SSH.sshCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent, profile, region)
+      SSH.sshCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent, profile, region, tunnelThroughSystemsManager)
     }
     val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
     ProgramResult(programResult.map(UI.sshOutput(rawOutput)))

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -143,7 +143,7 @@ object SSH {
   // The first file goes to the second file
   // The remote file is indicated by a colon
 
-  def scpCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File], sourceFile: String, targetFile: String): (InstanceId, Seq[Output]) = {
+  def scpCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File], sourceFile: String, targetFile: String, profile: Option[String], region: Region, tunnelThroughSystemsManager: Boolean): (InstanceId, Seq[Output]) = {
 
     def isRemote(filepath: String): Boolean = {
       filepath.startsWith(":")
@@ -158,6 +158,7 @@ object SSH {
       case _ => ""
     }
     val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
+    val proxyFragment = if(tunnelThroughSystemsManager) { s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile.map("--profile " + _).getOrElse("")}\\""""" } else { "" }
     val useAgentFragment = useAgent match {
       case None => ""
       case Some(decision) => if(decision) " -A" else " -a"
@@ -167,9 +168,9 @@ object SSH {
     if (exactlyOneArgumentIsRemote(sourceFile, targetFile)) {
       val connectionString =
         if (isRemote(sourceFile)) {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} $user@$ipAddress:${sourceFile.stripPrefix(":")} ${targetFile}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$proxyFragment${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} $user@$ipAddress:${sourceFile.stripPrefix(":")} ${targetFile}"""
         }else {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} ${sourceFile} $user@$ipAddress:${targetFile.stripPrefix(":")}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$proxyFragment${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} ${sourceFile} $user@$ipAddress:${targetFile.stripPrefix(":")}"""
         }
       val cmd = if(rawOutput) {
         Seq(Out(s"$connectionString", newline = false))

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -31,7 +31,8 @@ case class Arguments(
   useAgent: Option[Boolean],
   hostKeyAlgPreference: List[String],
   sourceFile: Option[String],
-  targetFile: Option[String]
+  targetFile: Option[String],
+  tunnelThroughSystemsManager: Boolean
 )
 
 object Arguments {
@@ -59,7 +60,8 @@ object Arguments {
     useAgent = None,
     hostKeyAlgPreference = defaultHostKeyAlgPreference,
     sourceFile = None,
-    targetFile = None
+    targetFile = None,
+    tunnelThroughSystemsManager = false
   )
 }
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 import com.amazonaws.regions.{Region, Regions}
 
 class SSHTest extends FreeSpec with Matchers with EitherValues {
+  private val EU_WEST_1 = Region.getRegion(Regions.EU_WEST_1)
 
   "create add key command" - {
     import SSH.addPublicKeyCommand
@@ -57,7 +58,6 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
     import SSH.sshCmdStandard
     import SSH.sshCmdBastion
     import SSH.sshCredentialsLifetimeSeconds
-    val EU_WEST_1 = Region.getRegion(Regions.EU_WEST_1)
 
     "create standard ssh command" - {
 
@@ -218,7 +218,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+        val (instanceId, _) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
         instanceId.id shouldEqual "raspberry"
       }
 
@@ -227,36 +227,36 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
         "process correctly remote server specifications" - {
 
           "target file is remote" in {
-            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
             command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
           }
           "source file is remote" in {
-            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
+            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
             command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile;"""))
           }
           "incorrect specifications in" in {
-            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
+            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
             command.head.text should include ("Incorrect remote server specifications")
           }
         }
 
         "is correctly formed without port specification" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
           command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
           command should contain (Out("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), Some(new File("/tmp/hostsfile")), "/path/to/sourceFile", ":/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), Some(new File("/tmp/hostsfile")), "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
           command should contain (Out("""scp -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(true), None, "/path/to/sourceFile", ":/path/to/targetFile")
+          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(true), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
           command should contain (Out("""scp -o "IdentitiesOnly yes" -A -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
         }
       }
@@ -265,27 +265,34 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
         "process correctly remote server specifications" - {
 
           "target file is remote" in {
-            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
             command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
           }
           "source file is remote" in {
-            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
+            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
             command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
           }
           "incorrect specifications in" in {
-            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile")
+            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
             command.head.text should include ("Incorrect remote server specifications")
           }
         }
 
         "is correctly formed without port specification" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile")
+          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
           command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile")
+          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
           command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+        }
+      }
+
+      "ssm tunnel" - {
+        "is correctly formed" in {
+          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = true)
+          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -4,6 +4,8 @@ import org.scalatest.{EitherValues, FreeSpec, Matchers}
 import java.io.File
 import java.time.Instant
 
+import com.amazonaws.regions.{Region, Regions}
+
 class SSHTest extends FreeSpec with Matchers with EitherValues {
 
   "create add key command" - {
@@ -55,6 +57,7 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
     import SSH.sshCmdStandard
     import SSH.sshCmdBastion
     import SSH.sshCredentialsLifetimeSeconds
+    val EU_WEST_1 = Region.getRegion(Regions.EU_WEST_1)
 
     "create standard ssh command" - {
 
@@ -62,40 +65,40 @@ class SSHTest extends FreeSpec with Matchers with EitherValues {
       val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+        val (instanceId, _) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1)
         instanceId.id shouldEqual "raspberry"
       }
 
       "user command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false))
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false), None, EU_WEST_1)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true))
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true), None, EU_WEST_1)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10;"""))
         }
       }
 
       "machine command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false))
+          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1)
           command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false))
+          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1)
           command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
         }
       }


### PR DESCRIPTION
## What does this change?

Adds `--ssm-tunnel` flag to [tunnel connections using AWS Systems Manager](https://aws.amazon.com/about-aws/whats-new/2019/07/session-manager-launches-tunneling-support-for-ssh-and-scp/). In practice this means you can access machines without the use of a bastion host and can close port 22 for access entirely, even within the VPC.

This requires the Systems Manager agent to be [at least 2.3.672.0](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html). ~Unfortunately this image is not yet in the Ubuntu base AMI images we use (not even the nightlies as of 19/07/19)~ The image is in the base images we use for AMIgo.

It also requires the instance policies to have additional `ssmmessages` [policy statements](https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-create-iam-instance-profile.html):

```yaml
- "ssm:UpdateInstanceInformation"
- "ssmmessages:CreateControlChannel"
- "ssmmessages:CreateDataChannel"
- "ssmmessages:OpenControlChannel"
- "ssmmessages:OpenDataChannel"
```

Because of these requirements I have added it behind a flag. It might be possible to remove the flag by performing a look-up to see if the instance is running the newer agent and tunnelling, falling back to the traditional SSH directly. Naturally this would negate the security benefit from closing port 22.

I think it would also be possible to make a version of `ssm-scala` that is designed to be run via `ProxyCommand` in ssh config, following the trick [suggested in the AWS docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html). It would initially provision the temporary SSH key on the machine and then open a proxy to the `aws-cli` that then in turn proxies to the machine. I will investigate further as this would provide us with a cleaner migration path being a totally separate command, but I think it's important to have the capability up front, hence the PR here.

## What is the value of this?

Increased security posture by supporting auditable SSH connections to instances without exposing port 22 outside of each instance.


## Any additional notes?