### PR TITLE
Add --ssm-tunnel to quick start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ The readme is quite detailled (and shows how to do many more things than what wi
 3. At your console type
 
 	```
-	ssm ssh -i i-00032c76140bc9140 -p frontend -x
+	ssm ssh --ssm-tunnel -i i-00032c76140bc9140 -p frontend -x
 	```
 	
 	and more generally
 
 	```
-	ssm ssh -i <instance-id> -p <accountName> -x
+	ssm ssh --ssm-tunnel -i <instance-id> -p <accountName> -x
 	```
 
 5. And that's it! If all went well you have been ssh'ed to the box. 


### PR DESCRIPTION
Wherever possible teams should be using --ssm-tunnel rather than IP restrictions to control instance access so maybe it deserves a place in the quick start docs? 

Counter argument: let's leave this out and wait till *everyone* is using --ssm-tunnel and then make that the default behaviour