### PR TITLE
Update version number and correct error message

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion := "2.12.4"
 
 name := "ssm-scala"
 organization := "com.gu"
-version := "1.6.1"
+version := "1.7.0"
 
 val awsSdkVersion = "1.11.847"
 

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -20,8 +20,8 @@ object Logic {
   }
 
   def extractSASTags(tags: Seq[String]): Either[String, List[String]] = {
-    if (tags.length < 1 || tags.head.length == 0) Left("Please supply at least an app, stack or stage tag. For example, -t grafana,PROD,deploy")
-    else if (tags.length > 10) Left("Please provide fewer tags")
+    if (tags.length < 1 || tags.head.length == 0) Left("Please supply an app, stack and stage tag in any order. For example, -t grafana,PROD,deploy")
+    else if (tags.length >= 10) Left("Please provide fewer than 10 tags")
     else Right(tags.toList)
   }
 


### PR DESCRIPTION
## What does this change?
Update version number, so that we can make a release and correct the error message as users still need to supply the app, stack and stage parameters (although they can do so in any order).