### PR TITLE
Allow user to just provide one tag rather than all 3.

### DIFF
--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -32,7 +32,8 @@ object ArgumentParser {
             _ => args,
             tagValues => args.copy(executionTarget = Some(ExecutionTarget(tagValues = Some(tagValues))))
           )
-      } text "Search for instances by tag e.g. '--tags app,stack,stage'"
+      } text "Search for instances by tag. If you provide less than 3 tags assumed order is app,stage,stack." +
+      " e.g. '--tags riff-raff,prod' or '--tags grafana' Upper/lowercase variations will be tried."
 
     opt[String]('r', "region").optional()
       .validate { region =>

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -20,8 +20,8 @@ object Logic {
   }
 
   def extractSASTags(tags: Seq[String]): Either[String, List[String]] = {
-    if (tags.length != 3) Left("Please provide app, stack and stage tags")
-    else if (tags.head.length == 0) Left("Please supply an app, stack and stage tag in any order. For example, -t grafana,PROD,deploy")
+    if (tags.length > 3 || tags.isEmpty || tags.head.length == 0) Left("Please supply at least one and no more than 3 tags. " +
+      "If you specify less than 3 tags order assumed is app,stage,stack")
     else Right(tags.toList)
   }
 

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -32,7 +32,7 @@ object EC2 {
     val allTags = tagValues ++ tagValues.map(_.toUpperCase) ++ tagValues.map(_.toLowerCase)
 
     // if user has provided fewer than 3 tags then assume order app,stage,stack
-    val tagOrder = List("App", "Stack", "Stage")
+    val tagOrder = List("App", "Stage", "Stack")
     val filters = tagOrder.take(tagValues.length).map(makeFilter(_, allTags))
 
     val request = new DescribeInstancesRequest()

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -21,10 +21,6 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
     "returns error if more than 3 tags are provided" in {
       extractSASTags(Seq("a", "b", "c", "d")).isLeft shouldEqual true
     }
-
-    "returns error if less than 3 tags are provided" in {
-      extractSASTags(Seq("a", "b")).isLeft shouldEqual true
-    }
   }
 
   "generateScript" - {


### PR DESCRIPTION
## What does this change?
This change follows from https://github.com/guardian/ssm-scala/pull/117 in an eternal quest to make ssh a bit easier. My proposal here is that we allow people to only specify one tag. For example it is now possible to do:

`ssm ssh -x -p deployTools -t grafana`
`ssm ssh -x -p deployTools -t prism,prod --newest`
`ssm ssh -x -p deployTools -t prod,prism --newest`
`ssm ssh -x -p deployTools -t api,code,flexible --newest`

I've also made the describeinstances call even more inefficient by trying to make it less case sensitive, so

`ssm ssh -x -p deployTools -t prism,prod --newest` will actually query:

describeinstances( app=prism|PRISM|prod|PROD, stage=prism|PRISM|prod|PROD)

I've tried to keep order as irrelevant as possible, but without doing multiple API lookups I needed a way to decide which filter to not include if less than 3 tags are provided. So if only one tag is provided, only the App tag is checked. if two are provided, then App and stage are checked (-t grafana,prod and -t prod,grafana are equivalent). If 3 tags are provided then the order doesn't matter.

## What is the value of this?
Faster SSH. This is partly just a 'nice to have' feature to encourage people to switch to SSM tunnel, which will become the default in the next release. 