### PR TITLE
Make --ssm-tunnel default behaviour.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion := "2.12.4"
 
 name := "ssm-scala"
 organization := "com.gu"
-version := "1.7.0"
+version := "2.0.0"
 
 val awsSdkVersion = "1.11.847"
 

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -153,6 +153,8 @@ object ArgumentParser {
         opt[String]("host-key-alg-preference").optional().unbounded()
           .action((alg, args) => args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference))
           .text(s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"),
+        opt[Unit]("ssm-tunnel").optional()
+          .text("[deprecated]"),
 
         opt[Unit]("no-ssm-proxy").optional()
           .action((_, args) => args.copy(tunnelThroughSystemsManager = false))
@@ -205,6 +207,8 @@ object ArgumentParser {
               rawOutput = true)
           })
           .text("Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"),
+        opt[Unit]("ssm-tunnel").optional()
+          .text("[deprecated]"),
         opt[Unit]("no-ssm-proxy").optional()
           .action((_, args) => args.copy(tunnelThroughSystemsManager = false))
           .text("Do not connect to the host proxying via AWS Systems Manager - go direct to port 22. Useful for instances running old versions of systems manager (< 2.3.672.0)"),

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -61,7 +61,7 @@ object Arguments {
     hostKeyAlgPreference = defaultHostKeyAlgPreference,
     sourceFile = None,
     targetFile = None,
-    tunnelThroughSystemsManager = false
+    tunnelThroughSystemsManager = true
   )
 }
 


### PR DESCRIPTION
## What does this change?
This modifies ssm-scala so that by default it tries to proxy requests via aws systems manager. This is the preferred approach, as documented in the [readme](https://github.com/guardian/ssm-scala#enabling-ssm-tunnel) as it means you don't have to open up port 22, don't need the VPN, and don't need bastion hosts. Oh my! 

I think enough time has passed since @mbarton 's initial PR https://github.com/guardian/ssm-scala/pull/111 for this to have become mostly standard practice, and this PR will save people having to remember to type `--ssm-tunnel` all the time. 

If ssm tunnel is not desired, the flag `--no-ssm-proxy` will disable this behaviour.

This combined with the work discussed here https://github.com/guardian/ssm-scala/pull/120 will allow you to ssh like this:

`ssm ssh -x -t grafana -p deployTools` 


## What is the value of this?
Firstly, it saves typing a few characters. Secondly, it pushes people towards a more convenient and secure way of accessing machines. 
