### PR TITLE
Wait indefinitely

### DIFF
--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -9,7 +9,6 @@ import com.gu.ssm.ArgumentParser.argParser
 
 object Main {
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
-  private val maximumWaitTime = 25.seconds
 
   def main(args: Array[String]): Unit = {
     val (result, verbose) = argParser.parse(args, Arguments.empty()) match {
@@ -76,7 +75,7 @@ object Main {
     } yield {
       SSH.sshCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent, profile, region, tunnelThroughSystemsManager)
     }
-    val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
+    val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
     ProgramResult(programResult.map(UI.sshOutput(rawOutput)))
   }
 
@@ -115,7 +114,7 @@ object Main {
       targetHostKey <- Attempt.fromEither(Logic.getHostKeyEntry(targetResult, preferredAlgs))
       hostKeyFile <- SSH.writeHostKey((bastionAddress, bastionHostKey), (targetAddress, targetHostKey))
     } yield SSH.sshCmdBastion(rawOutput)(privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile))
-    val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
+    val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
     ProgramResult(programResult.map(UI.sshOutput(rawOutput)))
   }
 
@@ -150,7 +149,7 @@ object Main {
     } yield {
       SSH.scpCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile), sourceFile, targetFile, profile, region, tunnelThroughSystemsManager)
     }
-    val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
+    val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
     ProgramResult(programResult.map(UI.sshOutput(rawOutput)))
   }
 
@@ -161,7 +160,7 @@ object Main {
       results <- IO.executeOnInstances(config.targets.map(i => i.id), user, toExecute, awsClients.ssmClient)
       incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(executionTarget, results.map(_._1))
     } yield ResultsWithInstancesNotFound(results,incorrectInstancesFromInstancesTag)
-    val programResult = Await.result(fProgramResult.asFuture, maximumWaitTime)
+    val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
     ProgramResult(programResult.map(UI.output))
   }
 }

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -64,7 +64,7 @@ object SSM {
 
   def getCmdOutput(instance: InstanceId, commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[(InstanceId, Either[CommandStatus, CommandResult])] = {
     for {
-      cmdResult <- Attempt.retryUntil(60, 500.millis, () => getCommandInvocation(instance, commandId, client))(_.isRight)
+      cmdResult <- Attempt.retryUntil(delayBetweenRetries = 500.millis, () => getCommandInvocation(instance, commandId, client))(_.isRight)
     } yield instance -> cmdResult
   }
 

--- a/src/main/scala/com/gu/ssm/utils/attempt/Attempt.scala
+++ b/src/main/scala/com/gu/ssm/utils/attempt/Attempt.scala
@@ -175,21 +175,17 @@ object Attempt {
     * Note that this will fail immediately with the failure if a FailedAttempt is returned,
     * this function is for testing the successful value.
     */
-  def retryUntil[A](maxRetries: Int, delayBetweenRetries: FiniteDuration, attemptA: () => Attempt[A])(condition: A => Boolean)
+  def retryUntil[A](delayBetweenRetries: FiniteDuration, attemptA: () => Attempt[A])(condition: A => Boolean)
               (implicit ec: ExecutionContext): Attempt[A] = {
     def loop(a: A, attemptCount: Int): Attempt[A] = {
       if (condition(a)) {
         Attempt.Right(a)
       } else {
-        if (attemptCount < maxRetries) {
-          for {
-            _ <- delay(delayBetweenRetries)
-            nextA <- attemptA()
-            result <- loop(nextA, attemptCount + 1)
-          } yield result
-        } else {
-          Attempt.Left(Failure("exceeded max retries", "Exceeded maximum number of retries while performing an operation", ErrorCode))
-        }
+        for {
+          _ <- delay(delayBetweenRetries)
+          nextA <- attemptA()
+          result <- loop(nextA, attemptCount + 1)
+        } yield result
       }
     }
 


### PR DESCRIPTION
In the investigations account we regularly hit this timeout simply running `ssm ssh`. I think this is because of the time it takes to establish a connection to the SSM agent as subsequent invocations do not time out. When the timeout does occur, ssm hangs rather than exits.

We'd also like to run scripts using `ssm cmd` that will take longer than 25 seconds.

I don't see value in having an arbitrary timeout across the entire program so after this change ssm will wait forever. I may well be missing the reason behind this timeout though.