### PR TITLE
Filters non-running instances from resolveByTag method

### DIFF
--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -33,7 +33,8 @@ object EC2 {
 
     // if user has provided fewer than 3 tags then assume order app,stage,stack
     val tagOrder = List("App", "Stage", "Stack")
-    val filters = tagOrder.take(tagValues.length).map(makeFilter(_, allTags))
+    val filters = new Filter("instance-state-name", List("running").asJava) ::
+        tagOrder.take(tagValues.length).map(makeFilter(_, allTags))
 
     val request = new DescribeInstancesRequest()
       .withFilters(


### PR DESCRIPTION
## What does this change?
This PR excludes non-running instances when running commands against a set of tags. 

This issue was noticed when testing instances were running Wazuh correctly after a deploy. The command was failing with AWS returning `InvalidInstanceId`. Commands run against a specific query ID worked fine. We determine that the commands were being run against the terminated instances due to the deploy.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
It should be easier to query recently deployed instances.


## Any additional notes?
I've tested this locally, I'm not sure if there are other ways to test.