### PR TITLE
Return error code if any invocation fails during ssm cmd

### DIFF
--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -42,7 +42,7 @@ class InteractiveProgram(val awsClients: AWSClients)(implicit ec: ExecutionConte
   def executeCommand(command: String, instances: List[InstanceId], username: String, instancesNotFound: List[InstanceId]): Unit = {
     IO.executeOnInstances(instances, username, command, awsClients.ssmClient).onComplete {
       case Right(results) =>
-        ui.displayResults(instances, username, ResultsWithInstancesNotFound(results, instancesNotFound, Logic.hasAnyCommandFailed(results)))
+        ui.displayResults(instances, username, ResultsWithInstancesNotFound(results, instancesNotFound))
       case Left(fa) =>
         ui.displayError(fa)
     }
@@ -159,14 +159,14 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
   def ready(instances: List[InstanceId], username: String, instancesToReport: List[InstanceId]): Unit = {
     logger.trace("resolved instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(instances, username, ResultsWithInstancesNotFound(Nil, instancesToReport, anyCommandFailed = false)))
+    textGUI.addWindow(mainWindow(instances, username, ResultsWithInstancesNotFound(Nil, instancesToReport)))
     textGUI.updateScreen()
   }
 
   def searching(): Unit = {
     logger.trace("waiting to resolve instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(List(), "", ResultsWithInstancesNotFound(Nil, Nil, anyCommandFailed = false)))
+    textGUI.addWindow(mainWindow(List(), "", ResultsWithInstancesNotFound(Nil, Nil)))
     textGUI.updateScreen()
   }
 

--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -109,7 +109,7 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
           case Right(cmdResult) =>
             cmdResult
           case Left(status) =>
-            CommandResult("", status.toString)
+            CommandResult("", status.toString, commandFailed = true)
         }
         i -> outputStreams
       }.toMap

--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -42,7 +42,7 @@ class InteractiveProgram(val awsClients: AWSClients)(implicit ec: ExecutionConte
   def executeCommand(command: String, instances: List[InstanceId], username: String, instancesNotFound: List[InstanceId]): Unit = {
     IO.executeOnInstances(instances, username, command, awsClients.ssmClient).onComplete {
       case Right(results) =>
-        ui.displayResults(instances, username, ResultsWithInstancesNotFound(results, instancesNotFound))
+        ui.displayResults(instances, username, ResultsWithInstancesNotFound(results, instancesNotFound, Logic.hasAnyCommandFailed(results)))
       case Left(fa) =>
         ui.displayError(fa)
     }
@@ -159,14 +159,14 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
   def ready(instances: List[InstanceId], username: String, instancesToReport: List[InstanceId]): Unit = {
     logger.trace("resolved instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(instances, username, ResultsWithInstancesNotFound(Nil, instancesToReport)))
+    textGUI.addWindow(mainWindow(instances, username, ResultsWithInstancesNotFound(Nil, instancesToReport, anyCommandFailed = false)))
     textGUI.updateScreen()
   }
 
   def searching(): Unit = {
     logger.trace("waiting to resolve instances and username, UI ready")
     textGUI.removeWindow(textGUI.getActiveWindow)
-    textGUI.addWindow(mainWindow(List(), "", ResultsWithInstancesNotFound(Nil, Nil)))
+    textGUI.addWindow(mainWindow(List(), "", ResultsWithInstancesNotFound(Nil, Nil, anyCommandFailed = false)))
     textGUI.updateScreen()
   }
 

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -80,8 +80,4 @@ object Logic {
     }
   }
 
-  def hasAnyCommandFailed(ssmResults: List[(InstanceId, Either[CommandStatus, CommandResult])]): Boolean = {
-    ssmResults.exists { case(_, result) => result.exists(_.commandFailed) }
-  }
-
 }

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -80,4 +80,8 @@ object Logic {
     }
   }
 
+  def hasAnyCommandFailed(ssmResults: List[(InstanceId, Either[CommandStatus, CommandResult])]): Boolean = {
+    ssmResults.exists { case(_, result) => result.exists(_.commandFailed) }
+  }
+
 }

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -162,10 +162,11 @@ object Main {
     } yield ResultsWithInstancesNotFound(results,incorrectInstancesFromInstancesTag)
 
     val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
+    val programOutput = ProgramResult(programResult.map(UI.output))
 
     val anyCommandFailed = programResult.exists(_.results.exists(_._2.map(_.commandFailed).getOrElse(false)))
-    val nonZeroExitCode = if(anyCommandFailed) { Some(ErrorCode) } else { None }
+    val nonZeroExitCode = if(programOutput.nonZeroExitCode.isEmpty && anyCommandFailed) { Some(ErrorCode) } else { programOutput.nonZeroExitCode }
 
-    ProgramResult(programResult.map(UI.output)).copy(nonZeroExitCode = nonZeroExitCode)
+    programOutput.copy(nonZeroExitCode = nonZeroExitCode)
   }
 }

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -1,8 +1,7 @@
 package com.gu.ssm
 
 import java.io.{ByteArrayOutputStream, PrintWriter}
-
-import com.gu.ssm.utils.attempt.{ExitCode, FailedAttempt}
+import com.gu.ssm.utils.attempt.{ErrorCode, ExitCode, FailedAttempt}
 
 import scala.collection.mutable
 
@@ -17,10 +16,10 @@ case class Verbose(text: String) extends Output
 
 case class ProgramResult(output: Seq[Output], nonZeroExitCode: Option[ExitCode] = None)
 object ProgramResult {
-  def apply(result: Either[FailedAttempt, Seq[Output]]): ProgramResult = {
-    result.fold[ProgramResult] (
-      failedAttempt => ProgramResult.apply(UI.outputFailure(failedAttempt), Some(failedAttempt.exitCode)),
-      output => ProgramResult.apply(output, None)
+  def apply(programResult: Either[FailedAttempt, ProgramResult]): ProgramResult = {
+    programResult.fold (
+      failedAttempt => ProgramResult(UI.outputFailure(failedAttempt), Some(failedAttempt.exitCode)),
+      identity
     )
   }
 }
@@ -41,7 +40,7 @@ object UI {
     }
   }
 
-  def output(extendedResults: ResultsWithInstancesNotFound): Seq[Output] = {
+  def output(extendedResults: ResultsWithInstancesNotFound): ProgramResult = {
     val buffer = mutable.Buffer.empty[Output]
     if(extendedResults.instancesNotFound.nonEmpty){
       buffer += Err(s"The following instance(s) could not be found: ${extendedResults.instancesNotFound.map(_.id).mkString(", ")}\n")
@@ -60,16 +59,18 @@ object UI {
         )
       }
     }
-    buffer.toList
+
+    val nonZeroExitCode = if(extendedResults.anyCommandFailed) { Some(ErrorCode) } else { None }
+    ProgramResult(buffer.toList, nonZeroExitCode)
   }
 
-  def sshOutput(rawOutput: Boolean)(result: (InstanceId, Seq[Output])): Seq[Output] = {
+  def sshOutput(rawOutput: Boolean)(result: (InstanceId, Seq[Output])): ProgramResult = ProgramResult(
     if (rawOutput){
       result._2
     } else {
       Metadata(s"========= ${result._1.id} =========") +: result._2
     }
-  }
+  )
 
   def outputFailure(failedAttempt: FailedAttempt): Seq[Output] = {
     failedAttempt.failures.flatMap { failure =>

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -54,9 +54,9 @@ object SSM {
   def extractCommandResult(getCommandInvocationResult: GetCommandInvocationResult): Either[CommandStatus, CommandResult] = {
     commandStatus(getCommandInvocationResult.getStatusDetails) match {
       case Success =>
-        Right(CommandResult(getCommandInvocationResult.getStandardOutputContent, getCommandInvocationResult.getStandardErrorContent))
+        Right(CommandResult(getCommandInvocationResult.getStandardOutputContent, getCommandInvocationResult.getStandardErrorContent, commandFailed = false))
       case Failed =>
-        Right(CommandResult(getCommandInvocationResult.getStandardOutputContent, getCommandInvocationResult.getStandardErrorContent))
+        Right(CommandResult(getCommandInvocationResult.getStandardOutputContent, getCommandInvocationResult.getStandardErrorContent, commandFailed = true))
       case status =>
         Left(status)
     }

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -99,8 +99,7 @@ case class AWSClients (
 
 case class ResultsWithInstancesNotFound(
   results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])],
-  instancesNotFound: List[InstanceId],
-  anyCommandFailed: Boolean
+  instancesNotFound: List[InstanceId]
 )
 
 sealed trait SingleInstanceSelectionMode

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -97,7 +97,11 @@ case class AWSClients (
   ec2Client: AmazonEC2Async
 )
 
-case class ResultsWithInstancesNotFound(results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])], instancesNotFound: List[InstanceId])
+case class ResultsWithInstancesNotFound(
+  results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])],
+  instancesNotFound: List[InstanceId],
+  anyCommandFailed: Boolean
+)
 
 sealed trait SingleInstanceSelectionMode
 case object SismNewest extends SingleInstanceSelectionMode

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -84,7 +84,7 @@ case object SsmRepl extends SsmMode
 case object SsmSsh extends SsmMode
 case object SsmScp extends SsmMode
 
-case class CommandResult(stdOut: String, stdErr: String)
+case class CommandResult(stdOut: String, stdErr: String, commandFailed: Boolean)
 
 case class SSMConfig (
   targets: List[Instance],

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -158,4 +158,23 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
       }
     }
   }
+
+  "hasAnyCommandFailed" - {
+    "returns false if no commands failed" in {
+      Logic.hasAnyCommandFailed(List(InstanceId("test") -> Right(CommandResult("", "", commandFailed = false)))) shouldBe false
+    }
+
+    "returns true if a single command failed" in {
+      Logic.hasAnyCommandFailed(List(InstanceId("test") -> Right(CommandResult("", "", commandFailed = true)))) shouldBe true
+    }
+
+    "returns true if at least one command failed" in {
+      val commands = List(
+        InstanceId("test1") -> Right(CommandResult("", "", commandFailed = true)),
+        InstanceId("test2") -> Right(CommandResult("", "", commandFailed = false))
+      )
+
+      Logic.hasAnyCommandFailed(commands) shouldBe true
+    }
+  }
 }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -158,23 +158,4 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
       }
     }
   }
-
-  "hasAnyCommandFailed" - {
-    "returns false if no commands failed" in {
-      Logic.hasAnyCommandFailed(List(InstanceId("test") -> Right(CommandResult("", "", commandFailed = false)))) shouldBe false
-    }
-
-    "returns true if a single command failed" in {
-      Logic.hasAnyCommandFailed(List(InstanceId("test") -> Right(CommandResult("", "", commandFailed = true)))) shouldBe true
-    }
-
-    "returns true if at least one command failed" in {
-      val commands = List(
-        InstanceId("test1") -> Right(CommandResult("", "", commandFailed = true)),
-        InstanceId("test2") -> Right(CommandResult("", "", commandFailed = false))
-      )
-
-      Logic.hasAnyCommandFailed(commands) shouldBe true
-    }
-  }
 }

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -136,17 +136,17 @@ class LogicTest extends FreeSpec with Matchers with EitherValues {
         """.stripMargin
 
       "return the host key using the first algorithm when there is a match" in {
-        val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "")), List("ecdsa-sha2-nistp256", "ssh-rsa"))
+        val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "", true)), List("ecdsa-sha2-nistp256", "ssh-rsa"))
         hostKey.right.value shouldBe "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKDHXJ6sXLoKprcNzMDLF6YVroaf5ycshemnS1TJggIA6cf/FW5EmdzUlf+P0QfBdLsqjBVBxQhyWTtHXD4Byds= root@ip-10-248-50-51"
       }
 
       "return the host key using the second algorithm when there is a match for the first" in {
-        val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "")), List("ecdsa-idontexist", "ssh-rsa"))
+        val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "", true)), List("ecdsa-idontexist", "ssh-rsa"))
         hostKey.right.value shouldBe "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgfV3YLgQ6PKhz3NHwFOhQA1ZgBBxYq9duNF0RdHezuBDQAdz51UKssvsIBi74/DuHk7RjaPPMZaC6yNkAuRMTyJk82S93GGow36iMTQD4HTpDuUFloT+SiTrjez/mkS2Wk+fm4brhjo9Xb8M3TXpOn65AXC/3mrB8JrZwx5Y9d2IwEQT1/r6aM1mUo2JJrSQJ1zv+3+ZFKfij1UncjG7rXsUegmR0lmt8bfAkpef1I+LK3CERgxRNCcuM80ptTws3vgxyP9cS60IiF7W1lwuwtvDvZ9LuDnHlrMi+t1t5EvwRm1CE9eLw9+qTQQijBFVjZlXT03St/6IJLMvBazI7 root@ip-10-248-50-51"
       }
 
       "error when there are no suitable host keys" in {
-        val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "")), List("ssh-bob"))
+        val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "", true)), List("ssh-bob"))
         hostKey.left.value.failures.head.friendlyMessage shouldBe "The remote instance did not return a host key with any preferred algorithm (preferred: List(ssh-bob))"
       }
     }

--- a/src/test/scala/com/gu/ssm/UITest.scala
+++ b/src/test/scala/com/gu/ssm/UITest.scala
@@ -1,0 +1,26 @@
+package com.gu.ssm
+
+import org.scalatest.{FreeSpec, Matchers}
+
+class UITest extends FreeSpec with Matchers {
+  "hasAnyCommandFailed" - {
+    "returns false if no commands failed" in {
+      val command = CommandResult("", "", commandFailed = false)
+      UI.hasAnyCommandFailed(List(InstanceId("test") -> Right(command))) shouldBe false
+    }
+
+    "returns true if a single command failed" in {
+      val command = CommandResult("", "", commandFailed = true)
+      UI.hasAnyCommandFailed(List(InstanceId("test") -> Right(command))) shouldBe true
+    }
+
+    "returns true if at least one command failed" in {
+      val commands = List(
+        InstanceId("test1") -> Right(CommandResult("", "", commandFailed = true)),
+        InstanceId("test2") -> Right(CommandResult("", "", commandFailed = false))
+      )
+
+      UI.hasAnyCommandFailed(commands) shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
At the moment, `ssm cmd` will return exit code 0 even if the underlying command has failed.

I'm trying to use it to run a script on a brand new EC2 instance, where the script is downloaded and installed by the launch configuration. If `ssm cmd` runs before the script has been downloaded, the command will result in an error (verified in the SSM web UI) but `ssm cmd` returns a success code.

It's also common to `set -e` in bash scripts to abandon execution on the first failure so the current behaviour can lead to cascading failures in subsequent commands.

This change returns exit code 1 if the command has failed on any of the targets. The stdout returned from the SSM agent will indicate the reason for the failure.