### PR TITLE
Scala style is 2 spaces, updates editorconfig accordingly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
## What does this change?

<!-- Screenshots may be helpful to demonstrate -->
The global editorconfig declaration was set to 4 spaces, which is at odds with Scala style and the existing codebase. This sets the default to 2 spaces for this project.


## What is the value of this?

Consistent formatting for people with editors configured to obey the editorconfig declaration.


## Any additional notes?

We might consider adding filetype-specific overrides to this configuration (e.g. `xml`, which currently uses 4 spaces in the
project), but my focus is on fixing this for the existing bulk of the program, which is Scala.