### PR TITLE
Use default AWS credentials if no profile is set

### DIFF
--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -51,6 +51,11 @@ object ArgumentParser {
     opt[Unit]("verbose").action( (_, c) =>
       c.copy(verbose = true) ).text("enable more verbose logging")
 
+    opt[Unit]("use-default-credentials-provider").optional()
+      .action((value, args) => args.copy(useDefaultCredentialsProvider = true))
+      .text("Use the default AWS credentials provider chain rather than profile credentials. " +
+            "This option is required when running within AWS itself.")
+
     cmd("cmd")
       .action((_, c) => c.copy(mode = Some(SsmCmd)))
       .text("Execute a single (bash) command, or a file containing bash commands")
@@ -228,6 +233,7 @@ object ArgumentParser {
       if (args.mode.isEmpty) Left("You must select a mode to use: cmd, repl or ssh")
       else if (args.toExecute.isEmpty && args.mode.contains(SsmCmd)) Left("You must provide commands to execute (src-file or cmd)")
       else if (args.executionTarget.isEmpty) Left("You must provide a list of target instances (-i) or instance App/Stage/Stack tags (-t)")
+      else if (!args.useDefaultCredentialsProvider && args.profile.isEmpty && !System.getenv().containsKey("AWS_PROFILE")) Left("Expected --profile, --use-default-credentials-provider or AWS_PROFILE environment variable")
       else Right(())
     }
   }

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -228,7 +228,6 @@ object ArgumentParser {
       if (args.mode.isEmpty) Left("You must select a mode to use: cmd, repl or ssh")
       else if (args.toExecute.isEmpty && args.mode.contains(SsmCmd)) Left("You must provide commands to execute (src-file or cmd)")
       else if (args.executionTarget.isEmpty) Left("You must provide a list of target instances (-i) or instance App/Stage/Stack tags (-t)")
-      else if (args.profile.isEmpty && !System.getenv().containsKey("AWS_PROFILE")) Left("--profile switch or environment variable AWS_PROFILE expected")
       else Right(())
     }
   }

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,8 +12,8 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val (result, verbose) = argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt, tunnelThroughSystemsManager)) =>
-        val awsClients = Logic.getClients(profile, region)
+      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt, tunnelThroughSystemsManager, useDefaultCredentialsProvider)) =>
+        val awsClients = Logic.getClients(profile, region, useDefaultCredentialsProvider)
         val r = mode match {
           case SsmRepl =>
             new InteractiveProgram(awsClients).main(profile, region, executionTarget)

--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -28,7 +28,7 @@ object AwsAsyncHandler {
       if (e.getMessage.contains("Request has expired")) {
         Failure("expired AWS credentials", "Failed to request data from AWS, the temporary credentials have expired", AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
-        Failure("Invalid AWS profile name (no credentials)", "No credentials found for the specified AWS profile", AwsPermissionsError, e).attempt
+        Failure("No AWS credentials found", "No AWS credentials found. Did you mean to set --profile?", AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("No AWS profile named")) {
         Failure("Invalid AWS profile name (does not exist)", "The specified AWS profile does not exist", AwsPermissionsError, e).attempt
       } else if (e.getMessage.contains("is not authorized to perform")) {

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -1,6 +1,6 @@
 package com.gu.ssm.aws
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.ec2.model._
@@ -14,13 +14,7 @@ import scala.concurrent.ExecutionContext
 
 
 object EC2 {
-  def client(profileName: Option[String], region: Region): AmazonEC2Async = {
-
-    val credentialsProvider = profileName match {
-      case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => DefaultAWSCredentialsProviderChain.getInstance()
-    }
-
+  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AmazonEC2Async = {
     AmazonEC2AsyncClientBuilder.standard()
       .withCredentials(credentialsProvider)
       .withRegion(region.getName)

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -1,5 +1,6 @@
 package com.gu.ssm.aws
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.ec2.model._
@@ -15,13 +16,13 @@ import scala.concurrent.ExecutionContext
 object EC2 {
   def client(profileName: Option[String], region: Region): AmazonEC2Async = {
 
-    val profileCredentialsProvider = profileName match {
+    val credentialsProvider = profileName match {
       case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => new ProfileCredentialsProvider()
+      case _ => DefaultAWSCredentialsProviderChain.getInstance()
     }
 
     AmazonEC2AsyncClientBuilder.standard()
-      .withCredentials(profileCredentialsProvider)
+      .withCredentials(credentialsProvider)
       .withRegion(region.getName)
       .build()
   }

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -1,26 +1,20 @@
 package com.gu.ssm.aws
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.simplesystemsmanagement.model._
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagementAsync, AWSSimpleSystemsManagementAsyncClientBuilder}
-import com.gu.ssm.{CommandStatus, _}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import com.gu.ssm.utils.attempt.Attempt
+import com.gu.ssm.{CommandStatus, _}
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 
 object SSM {
-  def client(profileName: Option[String], region: Region): AWSSimpleSystemsManagementAsync = {
-    val credentialsProvider = profileName match {
-      case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => DefaultAWSCredentialsProviderChain.getInstance()
-    }
-
+  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AWSSimpleSystemsManagementAsync = {
     AWSSimpleSystemsManagementAsyncClientBuilder.standard()
       .withCredentials(credentialsProvider)
       .withRegion(region.getName)

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -1,12 +1,13 @@
 package com.gu.ssm.aws
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.simplesystemsmanagement.model._
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagementAsync, AWSSimpleSystemsManagementAsyncClientBuilder}
 import com.gu.ssm.{CommandStatus, _}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import com.gu.ssm.utils.attempt.{Attempt}
+import com.gu.ssm.utils.attempt.Attempt
 
 import collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -15,13 +16,13 @@ import scala.concurrent.duration._
 
 object SSM {
   def client(profileName: Option[String], region: Region): AWSSimpleSystemsManagementAsync = {
-    val profileCredentialsProvider = profileName match {
+    val credentialsProvider = profileName match {
       case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => new ProfileCredentialsProvider()
+      case _ => DefaultAWSCredentialsProviderChain.getInstance()
     }
 
     AWSSimpleSystemsManagementAsyncClientBuilder.standard()
-      .withCredentials(profileCredentialsProvider)
+      .withCredentials(credentialsProvider)
       .withRegion(region.getName)
       .build()
   }

--- a/src/main/scala/com/gu/ssm/aws/STS.scala
+++ b/src/main/scala/com/gu/ssm/aws/STS.scala
@@ -1,8 +1,7 @@
 package com.gu.ssm.aws
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.securitytoken.model.{GetCallerIdentityRequest, GetCallerIdentityResult}
 import com.amazonaws.services.securitytoken.{AWSSecurityTokenServiceAsync, AWSSecurityTokenServiceAsyncClientBuilder}
@@ -13,13 +12,7 @@ import scala.concurrent.ExecutionContext
 
 
 object STS {
-  def client(profileName: Option[String], region: Region): AWSSecurityTokenServiceAsync = {
-
-    val credentialsProvider = profileName match {
-      case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => DefaultAWSCredentialsProviderChain.getInstance()
-    }
-
+  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AWSSecurityTokenServiceAsync = {
     AWSSecurityTokenServiceAsyncClientBuilder.standard()
       .withCredentials(credentialsProvider)
       // STS is a global service but you need to access the regional endpoint if using it through an endpoint in VPCs

--- a/src/main/scala/com/gu/ssm/aws/STS.scala
+++ b/src/main/scala/com/gu/ssm/aws/STS.scala
@@ -1,5 +1,6 @@
 package com.gu.ssm.aws
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.regions.Region
@@ -14,13 +15,13 @@ import scala.concurrent.ExecutionContext
 object STS {
   def client(profileName: Option[String], region: Region): AWSSecurityTokenServiceAsync = {
 
-    val profileCredentialsProvider = profileName match {
+    val credentialsProvider = profileName match {
       case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => new ProfileCredentialsProvider()
+      case _ => DefaultAWSCredentialsProviderChain.getInstance()
     }
 
     AWSSecurityTokenServiceAsyncClientBuilder.standard()
-      .withCredentials(profileCredentialsProvider)
+      .withCredentials(credentialsProvider)
       // STS is a global service but you need to access the regional endpoint if using it through an endpoint in VPCs
       // that have no outbound internet access. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
       .withEndpointConfiguration(new EndpointConfiguration(region.getServiceEndpoint("sts"), region.getName))

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -32,7 +32,8 @@ case class Arguments(
   hostKeyAlgPreference: List[String],
   sourceFile: Option[String],
   targetFile: Option[String],
-  tunnelThroughSystemsManager: Boolean
+  tunnelThroughSystemsManager: Boolean,
+  useDefaultCredentialsProvider: Boolean
 )
 
 object Arguments {
@@ -61,7 +62,8 @@ object Arguments {
     hostKeyAlgPreference = defaultHostKeyAlgPreference,
     sourceFile = None,
     targetFile = None,
-    tunnelThroughSystemsManager = true
+    tunnelThroughSystemsManager = true,
+    useDefaultCredentialsProvider = false
   )
 }
 


### PR DESCRIPTION
We are automating AMI rotation for our neo4j instance in Giant using a bash script that calls `ssm cmd` to run commands. To run this automatically I'd like to simply run the same script in AWS but unfortunately I get an error:

```
--profile switch or environment variable AWS_PROFILE expected
```

It doesn't help if I `export AWS_PROFILE=default` as AWS credentials are not provided using a file but via the EC2/ECS metadata service:

```
"The config profile (default) could not be found"
```

This PR adds a `--use-default-credentials-provider` flag which we can set if running the script in AWS itself. We've deliberately decided to deviate from the standard `aws` CLI behaviour here so that people can't unexpectedly run commands using credentials in the default profile if they forget the `--profile` argument.
