### PR TITLE
Don't hide error messages when we can't determine the service name

### DIFF
--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -37,11 +37,11 @@ object AwsAsyncHandler {
       } else if (e.getMessage.contains("InvalidInstanceId")) {
         Failure("InvalidInstanceId from AWS", "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)", AwsError, e).attempt
       } else {
-        val details = serviceNameOpt.fold(s"AWS unknown error, unknown service (check logs for stacktrace). ${e.getMessage}") { serviceName =>
-          s"AWS unknown error, service: $serviceName (check logs for stacktrace), ${e.getMessage}"
+        val details = serviceNameOpt.fold(s"AWS unknown error, unknown service (check logs for stacktrace). $e") { serviceName =>
+          s"AWS unknown error, service: $serviceName (check logs for stacktrace), $e"
         }
-        val friendlyMessage = serviceNameOpt.fold(s"Unknown error while making API calls to AWS. ${e.getMessage}") { serviceName =>
-          s"Unknown error while making an API call to AWS' $serviceName service, ${e.getMessage}"
+        val friendlyMessage = serviceNameOpt.fold(s"Unknown error while making API calls to AWS. $e") { serviceName =>
+          s"Unknown error while making an API call to AWS' $serviceName service, $e"
         }
         Failure(details, friendlyMessage, AwsError, e).attempt
       }

--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -37,10 +37,10 @@ object AwsAsyncHandler {
       } else if (e.getMessage.contains("InvalidInstanceId")) {
         Failure("InvalidInstanceId from AWS", "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)", AwsError, e).attempt
       } else {
-        val details = serviceNameOpt.fold("AWS unknown error, unknown service (check logs for stacktrace)") { serviceName =>
+        val details = serviceNameOpt.fold(s"AWS unknown error, unknown service (check logs for stacktrace). ${e.getMessage}") { serviceName =>
           s"AWS unknown error, service: $serviceName (check logs for stacktrace), ${e.getMessage}"
         }
-        val friendlyMessage = serviceNameOpt.fold("Unknown error while making API calls to AWS.") { serviceName =>
+        val friendlyMessage = serviceNameOpt.fold(s"Unknown error while making API calls to AWS. ${e.getMessage}") { serviceName =>
           s"Unknown error while making an API call to AWS' $serviceName service, ${e.getMessage}"
         }
         Failure(details, friendlyMessage, AwsError, e).attempt


### PR DESCRIPTION
For example, the error you get if you haven't created a VPC endpoint for STS and don't have outbound internet access:

```
Unable to execute HTTP request: Connect to sts.amazonaws.com:443 [sts.amazonaws.com/52.94.241.129] failed: connect timed out
```