### PR TITLE
chore: Bump sbt to 1.5.7

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -10,6 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: lokkju/github-action-sbt@master
+      - name: Setup Java 8
+        uses: actions/setup-java@v2
         with:
-          commands: test
+          java-version: '8'
+          distribution: 'adopt'
+      - run: sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -20,4 +20,4 @@ libraryDependencies ++= Seq(
 )
 
 scalacOptions := Seq("-unchecked", "-deprecation")
-assemblyJarName in assembly := "ssm.jar"
+assembly / assemblyJarName := "ssm.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -4,19 +4,19 @@ name := "ssm-scala"
 organization := "com.gu"
 version := "2.3.0"
 
-val awsSdkVersion = "1.11.847"
+val awsSdkVersion = "1.12.129"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
-  "com.github.scopt" %% "scopt" % "3.7.0",
+  "com.github.scopt" %% "scopt" % "3.7.1",
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
-  "ch.qos.logback" %  "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6",
-  "org.bouncycastle" % "bcpkix-jdk15on" % "1.60",
-  "org.scalatest" %% "scalatest" % "3.0.4" % Test
+  "ch.qos.logback" %  "logback-classic" % "1.2.8",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
+  "org.bouncycastle" % "bcpkix-jdk15on" % "1.69",
+  "org.scalatest" %% "scalatest" % "3.2.9" % Test
 )
 
 scalacOptions := Seq("-unchecked", "-deprecation")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.5.7

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -1,11 +1,12 @@
 package com.gu.ssm
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
+
 import java.time.{Instant, LocalDateTime, ZoneId}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-import com.gu.ssm.utils.attempt.{FailedAttempt, Failure, NoHostKey}
-
-class LogicTest extends FreeSpec with Matchers with EitherValues {
+class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
   "extractSASTags" - {
     import Logic.extractSASTags
 

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -1,10 +1,12 @@
 package com.gu.ssm
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import com.gu.ssm.Logic.computeIncorrectInstances
 
 
-class MainTest extends FreeSpec with Matchers with EitherValues {
+class MainTest extends AnyFreeSpec with Matchers with EitherValues {
 
   "computeIncorrectInstances" - {
     "should return empty list when matching list of Instance Ids" in {

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -1,12 +1,14 @@
 package com.gu.ssm
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
+
 import java.io.File
 import java.time.Instant
-
 import com.amazonaws.regions.{Region, Regions}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SSHTest extends FreeSpec with Matchers with EitherValues {
+class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
   private val EU_WEST_1 = Region.getRegion(Regions.EU_WEST_1)
 
   "create add key command" - {

--- a/src/test/scala/com/gu/ssm/UITest.scala
+++ b/src/test/scala/com/gu/ssm/UITest.scala
@@ -1,8 +1,9 @@
 package com.gu.ssm
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class UITest extends FreeSpec with Matchers {
+class UITest extends AnyFreeSpec with Matchers {
   "hasAnyCommandFailed" - {
     "returns false if no commands failed" in {
       val command = CommandResult("", "", commandFailed = false)

--- a/src/test/scala/com/gu/ssm/utils/attempt/AttemptTest.scala
+++ b/src/test/scala/com/gu/ssm/utils/attempt/AttemptTest.scala
@@ -1,16 +1,17 @@
 package com.gu.ssm.utils.attempt
 
 import java.util.concurrent.TimeoutException
-
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
 import Attempt.{Left, Right}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
-class AttemptTest extends FreeSpec with Matchers with EitherValues with AttemptValues {
+class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with AttemptValues {
   "traverse" - {
     "returns the first failure" in {
       def failOnFourAndSix(i: Int): Attempt[Int] = {

--- a/src/test/scala/com/gu/ssm/utils/attempt/AttemptValues.scala
+++ b/src/test/scala/com/gu/ssm/utils/attempt/AttemptValues.scala
@@ -1,9 +1,8 @@
 package com.gu.ssm.utils.attempt
 
 import java.io.{ByteArrayOutputStream, PrintWriter}
-
-import org.scalatest.Matchers
 import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}


### PR DESCRIPTION
This is to remediate CVE-2021-44228.

Note: CI has been updated to use the action provided by GitHub as the previous one [wasn't working](https://github.com/guardian/ssm-scala/runs/4547658581?check_suite_focus=true):

```log
  Step 8/11 : RUN   curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb &&   dpkg -i sbt-$SBT_VERSION.deb &&   rm sbt-$SBT_VERSION.deb
   ---> Running in 0ff3fe5c20c3
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  100   166  100   166    0     0    410      0 --:--:-- --:--:-- --:--:--   410
  dpkg-deb: error: 'sbt-1.3.0.deb' is not a debian format archive
  dpkg: error processing archive sbt-1.3.0.deb (--install):
   subprocess dpkg-deb --control returned error exit status 2
  Errors were encountered while processing:
   sbt-1.3.0.deb
  The command '/bin/sh -c curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb &&   dpkg -i sbt-$SBT_VERSION.deb &&   rm sbt-$SBT_VERSION.deb' returned a non-zero code: 1
```