### PR TITLE
chore: Bump dependencies to latest minor version available

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.69",
-  "org.scalatest" %% "scalatest" % "3.0.4" % Test
+  "org.scalatest" %% "scalatest" % "3.2.9" % Test
 )
 
 scalacOptions := Seq("-unchecked", "-deprecation")

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
-  "com.github.scopt" %% "scopt" % "3.7.0",
+  "com.github.scopt" %% "scopt" % "3.7.1",
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
   "ch.qos.logback" %  "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ssm-scala"
 organization := "com.gu"
 version := "2.3.0"
 
-val awsSdkVersion = "1.11.847"
+val awsSdkVersion = "1.12.129"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
-  "ch.qos.logback" %  "logback-classic" % "1.2.3",
+  "ch.qos.logback" %  "logback-classic" % "1.2.8",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.60",

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
   "ch.qos.logback" %  "logback-classic" % "1.2.8",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.60",
   "org.scalatest" %% "scalatest" % "3.0.4" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" %  "logback-classic" % "1.2.8",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
-  "org.bouncycastle" % "bcpkix-jdk15on" % "1.60",
+  "org.bouncycastle" % "bcpkix-jdk15on" % "1.69",
   "org.scalatest" %% "scalatest" % "3.0.4" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
   "ch.qos.logback" %  "logback-classic" % "1.2.8",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.60",
   "org.scalatest" %% "scalatest" % "3.0.4" % Test
 )

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -1,11 +1,12 @@
 package com.gu.ssm
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
+
 import java.time.{Instant, LocalDateTime, ZoneId}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-import com.gu.ssm.utils.attempt.{FailedAttempt, Failure, NoHostKey}
-
-class LogicTest extends FreeSpec with Matchers with EitherValues {
+class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
   "extractSASTags" - {
     import Logic.extractSASTags
 

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -1,10 +1,12 @@
 package com.gu.ssm
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import com.gu.ssm.Logic.computeIncorrectInstances
 
 
-class MainTest extends FreeSpec with Matchers with EitherValues {
+class MainTest extends AnyFreeSpec with Matchers with EitherValues {
 
   "computeIncorrectInstances" - {
     "should return empty list when matching list of Instance Ids" in {

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -1,12 +1,14 @@
 package com.gu.ssm
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
+
 import java.io.File
 import java.time.Instant
-
 import com.amazonaws.regions.{Region, Regions}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SSHTest extends FreeSpec with Matchers with EitherValues {
+class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
   private val EU_WEST_1 = Region.getRegion(Regions.EU_WEST_1)
 
   "create add key command" - {

--- a/src/test/scala/com/gu/ssm/UITest.scala
+++ b/src/test/scala/com/gu/ssm/UITest.scala
@@ -1,8 +1,9 @@
 package com.gu.ssm
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class UITest extends FreeSpec with Matchers {
+class UITest extends AnyFreeSpec with Matchers {
   "hasAnyCommandFailed" - {
     "returns false if no commands failed" in {
       val command = CommandResult("", "", commandFailed = false)

--- a/src/test/scala/com/gu/ssm/utils/attempt/AttemptTest.scala
+++ b/src/test/scala/com/gu/ssm/utils/attempt/AttemptTest.scala
@@ -1,16 +1,17 @@
 package com.gu.ssm.utils.attempt
 
 import java.util.concurrent.TimeoutException
-
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
 import Attempt.{Left, Right}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
-class AttemptTest extends FreeSpec with Matchers with EitherValues with AttemptValues {
+class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with AttemptValues {
   "traverse" - {
     "returns the first failure" in {
       def failOnFourAndSix(i: Int): Attempt[Int] = {

--- a/src/test/scala/com/gu/ssm/utils/attempt/AttemptValues.scala
+++ b/src/test/scala/com/gu/ssm/utils/attempt/AttemptValues.scala
@@ -1,9 +1,8 @@
 package com.gu.ssm.utils.attempt
 
 import java.io.{ByteArrayOutputStream, PrintWriter}
-
-import org.scalatest.Matchers
 import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}


### PR DESCRIPTION
## What does this change?

Bumps dependencies to latest minor version available.

Note:
  - It looks like `scalatest` v3.2.9 has a different package layout, so imports across the tests have also been updated.
  - `scopt` has a v4 release. As this is a major change it's likely to include breaking changes and should be upgraded separately.