### PR TITLE
chore(deps): jackson-databind 2.13.0 -> 2.14.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.googlecode.lanterna" % "lanterna" % "3.0.0",
   "ch.qos.logback" %  "logback-classic" % "1.2.8",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.0",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.69",
   "org.scalatest" %% "scalatest" % "3.2.9" % Test
 )


### PR DESCRIPTION
## What does this change?

Updates jackson-databind 2.13.0 -> 2.14.0 to avoid https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244

## What is the value of this?

Nice & secure!