### PR TITLE
Batch Scala Steward updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.googlecode.lanterna" % "lanterna" % "3.1.1",
   "ch.qos.logback" %  "logback-classic" % "1.4.4",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.0",
   "org.bouncycastle" % "bcpkix-jdk18on" % "1.72",
   "org.scalatest" %% "scalatest" % "3.2.14" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" %  "logback-classic" % "1.2.11",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
-  "org.bouncycastle" % "bcpkix-jdk15on" % "1.70",
+  "org.bouncycastle" % "bcpkix-jdk18on" % "1.72",
   "org.scalatest" %% "scalatest" % "3.2.14" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.github.scopt" %% "scopt" % "4.1.0",
   "com.googlecode.lanterna" % "lanterna" % "3.0.4",
-  "ch.qos.logback" %  "logback-classic" % "1.2.11",
+  "ch.qos.logback" %  "logback-classic" % "1.4.4",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
   "org.bouncycastle" % "bcpkix-jdk18on" % "1.72",

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.github.scopt" %% "scopt" % "4.1.0",
-  "com.googlecode.lanterna" % "lanterna" % "3.0.4",
+  "com.googlecode.lanterna" % "lanterna" % "3.1.1",
   "ch.qos.logback" %  "logback-classic" % "1.4.4",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ssm-scala"
 organization := "com.gu"
 version := "2.3.0"
 
-val awsSdkVersion = "1.12.339"
+val awsSdkVersion = "1.12.341"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")

--- a/src/main/scala/com/gu/ssm/Interactive.scala
+++ b/src/main/scala/com/gu/ssm/Interactive.scala
@@ -118,10 +118,14 @@ class InteractiveUI(program: InteractiveProgram) extends LazyLogging {
       errOutputBox.setForegroundColor(TextColor.ANSI.RED)
       val stdOutputBox = new Label(outputs(0).stdOut)
 
-      val instancesComboBox = new ComboBox(instances.map(_.id):_*).addListener { (selectedIndex: Int, _: Int) =>
-        errOutputBox.setText(outputs(selectedIndex).stdErr)
-        stdOutputBox.setText(outputs(selectedIndex).stdOut)
+      val listener = new ComboBox.Listener {
+        override def onSelectionChanged(selectedIndex: Int, previousSelection: Int, changedByUserInteraction: Boolean): Unit = {
+          errOutputBox.setText(outputs(selectedIndex).stdErr)
+          stdOutputBox.setText(outputs(selectedIndex).stdOut)
+        }
       }
+
+      val instancesComboBox: ComboBox[String] = new ComboBox(instances.map(_.id):_*).addListener(listener)
       contentPanel.addComponent(instancesComboBox)
 
       contentPanel.addComponent(new EmptySpace())


### PR DESCRIPTION
## What does this change?

This change batches the updates in:

- https://github.com/guardian/ssm-scala/pull/161
- https://github.com/guardian/ssm-scala/pull/158
- https://github.com/guardian/ssm-scala/pull/157
- https://github.com/guardian/ssm-scala/pull/156
- https://github.com/guardian/ssm-scala/pull/155
- https://github.com/guardian/ssm-scala/pull/154
- https://github.com/guardian/ssm-scala/pull/142

## Why?

This updates all recommended libraries and removes some identified vulnerabilities. 

**Note:**  We should set up batched Scala steward updates for this repository.