### PR TITLE
Add commands for SSH tunnelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,26 @@ ssm ssh --profile security -t security-hq,security,PROD --newest --execute
 
 instead of the example given in the previous `--raw` section.
 
+### --tunnel
+
+This flag forwards traffic from a local port through the instance to the specified hostname and port. For example,
+
+```
+ssm ssh --profile security -t security-hq,security,PROD --newest -x --tunnel 5000:example.com:6000
+```
+
+would forward all traffic on your machine through the remote instance to example.com:6000.
+
+### ---rds-tunnel
+
+Similar to `tunnel`, this flag forwards traffic from a local port to an AWS RDS database specified by the given tags. For example,
+
+```
+ssm ssh --profile security -t security-hq,security,PROD --newest -x --rds-tunnel 5000:example-db,security,CODE
+```
+
+would try to find a single RDS instance with the tags `example-db,security,CODE`, and forward traffic from port 5000 to that RDS instance via the remote instance.
+
 ## Disabling SSM Tunnel
 **By default, SSM proxies your connection via AWS systems manager**, which saves you from opening up port 22, connecting to
 the VPN, or using bastion hosts. This requires a recent version of systems manager to be runnning on your machine and

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-rds" % awsSdkVersion,
   "com.github.scopt" %% "scopt" % "4.1.0",
   "com.googlecode.lanterna" % "lanterna" % "3.1.1",
   "ch.qos.logback" %  "logback-classic" % "1.4.5",

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -20,9 +20,14 @@ object IO {
     }.getOrElse(Attempt.Left(Failure("Unable to resolve execution target", "You must provide an execution target (instance(s) or tags)", ArgumentsError)))
   }
 
-  def resolveRDSInstances(tunnelTarget: TunnelTarget, rdsClient: AmazonRDSAsync)(implicit ec: ExecutionContext): Attempt[List[RDSInstance]] = tunnelTarget match {
-    case TunnelTargetWithTags(_, remoteTags, _) =>
-      RDS.resolveByTags(remoteTags.toList, rdsClient)
+  def resolveTunnelTarget(tunnelTarget: TunnelTarget, rdsClient: AmazonRDSAsync)(implicit ec: ExecutionContext): Attempt[TunnelTargetWithHostName] = tunnelTarget match {
+    case TunnelTargetWithTags(localPort, remoteTags, remotePort) =>
+      RDS.resolveByTags(remoteTags.toList, rdsClient).flatMap {
+        case rdsInstance :: Nil => Attempt.Right(TunnelTargetWithHostName(localPort, rdsInstance.hostname, remotePort))
+        case tooManyInstances => Attempt.Left(Failure("More than one tunnel target resolved from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${remoteTags.mkString(", ")}", ArgumentsError))
+        case Nil => Attempt.Left(Failure("Could not find target from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${remoteTags.mkString(", ")}", ArgumentsError))
+      }
+    case hostTarget: TunnelTargetWithHostName => Attempt.Right(hostTarget)
   }
 
   def executeOnInstances(instanceIds: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -24,8 +24,9 @@ object IO {
     case TunnelTargetWithTags(localPort, remoteTags, remotePort) =>
       RDS.resolveByTags(remoteTags.toList, rdsClient).flatMap {
         case rdsInstance :: Nil => Attempt.Right(TunnelTargetWithHostName(localPort, rdsInstance.hostname, remotePort))
-        case tooManyInstances => Attempt.Left(Failure("More than one tunnel target resolved from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${remoteTags.mkString(", ")}", ArgumentsError))
-        case Nil => Attempt.Left(Failure("Could not find target from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${remoteTags.mkString(", ")}", ArgumentsError))
+        case Nil => Attempt.Left(Failure("Could not find target from tags", s"We could not find an RDS instance with the tags: ${remoteTags.mkString(", ")}", ArgumentsError))
+        case tooManyInstances =>
+          Attempt.Left(Failure("More than one tunnel target resolved from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${remoteTags.mkString(", ")}", ArgumentsError))
       }
     case hostTarget: TunnelTargetWithHostName => Attempt.Right(hostTarget)
   }

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -22,7 +22,7 @@ object IO {
 
   def resolveRDSTunnelTarget(target: TunnelTargetWithRDSTags, rdsClient: AmazonRDSAsync)(implicit ec: ExecutionContext): Attempt[TunnelTargetWithHostName] = {
     RDS.resolveByTags(target.remoteTags.toList, rdsClient).flatMap {
-      case rdsInstance :: Nil => Attempt.Right(TunnelTargetWithHostName(target.localPort, rdsInstance.hostname, rdsInstance.port))
+      case rdsInstance :: Nil => Attempt.Right(TunnelTargetWithHostName(target.localPort, rdsInstance.hostname, rdsInstance.port, target.remoteTags))
       case Nil => Attempt.Left(Failure("Could not find target from tags", s"We could not find an RDS instance with the tags: ${target.remoteTags.mkString(", ")}", ArgumentsError))
       case tooManyInstances =>
         Attempt.Left(Failure("More than one tunnel target resolved from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${target.remoteTags.mkString(", ")}", ArgumentsError))

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -12,6 +12,9 @@ import com.gu.ssm.aws.{EC2, SSM, STS}
 import com.gu.ssm.utils.attempt._
 
 import scala.io.Source
+import com.amazonaws.services.rds.AmazonRDSClient
+import com.amazonaws.services.rds.AmazonRDSAsync
+import com.gu.ssm.aws.RDS
 
 object Logic {
   def generateScript(toExecute: Either[String, File]): String = {
@@ -71,7 +74,8 @@ object Logic {
     val ssmClient: AWSSimpleSystemsManagementAsync = SSM.client(credentialsProvider, region)
     val stsClient: AWSSecurityTokenServiceAsync = STS.client(credentialsProvider, region)
     val ec2Client: AmazonEC2Async = EC2.client(credentialsProvider, region)
-    AWSClients(ssmClient, stsClient, ec2Client)
+    val rdsClient: AmazonRDSAsync = RDS.client(credentialsProvider, region)
+    AWSClients(ssmClient, stsClient, ec2Client, rdsClient)
   }
 
   def computeIncorrectInstances(executionTarget: ExecutionTarget, instanceIds: List[InstanceId]): List[InstanceId] =

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val (result, verbose) = argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt, tunnelThroughSystemsManager, useDefaultCredentialsProvider)) =>
+      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt, tunnelThroughSystemsManager, useDefaultCredentialsProvider, tunnelTarget)) =>
         val awsClients = Logic.getClients(profile, region, useDefaultCredentialsProvider)
         val r = mode match {
           case SsmRepl =>

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -103,7 +103,7 @@ object SSH {
     }
     val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
     val proxyFragment = if(tunnelThroughSystemsManager) { s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile.map("--profile " + _).getOrElse("")}\\""""" } else { "" }
-    val tunnelString = tunnelTarget.map(t => s"-L ${t.localPort}:${t.remoteHostName}:${t.remotePort}").getOrElse("")
+    val tunnelString = tunnelTarget.map(t => s"-L ${t.localPort}:${t.remoteHostName}:${t.remotePort} -N -f").getOrElse("")
     val connectionString = s"""ssh -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$targetPortSpecifications$proxyFragment -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress $tunnelString""".trim()
 
     val cmd = if (rawOutput) {

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -91,7 +91,7 @@ object SSH {
        | for hostkey in $(sshd -T 2> /dev/null |grep "^hostkey " | cut -d ' ' -f 2); do cat $hostkey.pub; done
      """.stripMargin
 
-  def sshCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], hostsFile: Option[File], useAgent: Option[Boolean], profile: Option[String], region: Region, tunnelThroughSystemsManager: Boolean): (InstanceId, Seq[Output]) = {
+  def sshCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], hostsFile: Option[File], useAgent: Option[Boolean], profile: Option[String], region: Region, tunnelThroughSystemsManager: Boolean, tunnelTarget: Option[TunnelTargetWithHostName]): (InstanceId, Seq[Output]) = {
     val targetPortSpecifications = targetInstancePortNumberOpt match {
       case Some(portNumber) => s" -p ${portNumber}"
       case _ => ""
@@ -103,7 +103,8 @@ object SSH {
     }
     val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
     val proxyFragment = if(tunnelThroughSystemsManager) { s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile.map("--profile " + _).getOrElse("")}\\""""" } else { "" }
-    val connectionString = s"""ssh -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$targetPortSpecifications$proxyFragment -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress"""
+    val tunnelString = tunnelTarget.map(t => s"-L ${t.localPort}:${t.remoteHostName}:${t.remotePort}").getOrElse("")
+    val connectionString = s"""ssh -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$targetPortSpecifications$proxyFragment -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress $tunnelString""".trim()
 
     val cmd = if (rawOutput) {
       Seq(Out(s"$connectionString", newline = false))

--- a/src/main/scala/com/gu/ssm/aws/RDS.scala
+++ b/src/main/scala/com/gu/ssm/aws/RDS.scala
@@ -33,7 +33,7 @@ object RDS {
   }
 
   private def hasTagList(tagValues: List[String])(awsInstance: DBInstance): Boolean = {
-    val instanceTags = awsInstance.getTagList().asScala.toList.map(_.getKey())
+    val instanceTags = awsInstance.getTagList().asScala.toList.map(_.getValue())
     tagValues.forall(requiredTag => instanceTags.contains(requiredTag))
   }
 

--- a/src/main/scala/com/gu/ssm/aws/RDS.scala
+++ b/src/main/scala/com/gu/ssm/aws/RDS.scala
@@ -1,0 +1,44 @@
+package com.gu.ssm.aws
+
+import com.amazonaws.services.rds.model.{DescribeDBInstancesRequest, Filter}
+import com.amazonaws.services.rds.AmazonRDSAsync
+import com.gu.ssm.utils.attempt.Attempt
+import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.amazonaws.services.rds.AmazonRDSAsyncClientBuilder
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
+import com.gu.ssm.RDSInstance
+import com.gu.ssm.RDSInstanceId
+import com.amazonaws.services.rds.model.DBInstance
+
+object RDS {
+  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AmazonRDSAsync = {
+    AmazonRDSAsyncClientBuilder.standard()
+      .withCredentials(credentialsProvider)
+      .withRegion(region.getName)
+      .build()
+  }
+
+  def resolveByTags(tagValues: List[String], client: AmazonRDSAsync)(implicit ec: ExecutionContext): Attempt[List[RDSInstance]] = {
+    val request = new DescribeDBInstancesRequest()
+
+    handleAWSErrs(awsToScala(client.describeDBInstancesAsync)(request).map { result =>
+      result.getDBInstances.asScala.toList
+        .filter(hasTagList(tagValues))
+        .map(toInstance)
+    })
+  }
+
+  private def hasTagList(tagValues: List[String])(awsInstance: DBInstance): Boolean = {
+    val instanceTags = awsInstance.getTagList().asScala.toList.map(_.getKey())
+    tagValues.forall(requiredTag => instanceTags.contains(requiredTag))
+  }
+
+  private def toInstance(awsInstance: DBInstance): RDSInstance = {
+    val endpoint = awsInstance.getEndpoint()
+    RDSInstance(RDSInstanceId(awsInstance.getDBInstanceIdentifier()), endpoint.getAddress(), endpoint.getPort())
+  }
+}

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -37,7 +37,8 @@ case class Arguments(
   targetFile: Option[String],
   tunnelThroughSystemsManager: Boolean,
   useDefaultCredentialsProvider: Boolean,
-  tunnelTarget: Option[TunnelTarget]
+  tunnelTarget: Option[TunnelTargetWithHostName],
+  rdsTunnelTarget: Option[TunnelTargetWithRDSTags]
 )
 
 object Arguments {
@@ -68,7 +69,8 @@ object Arguments {
     targetFile = None,
     tunnelThroughSystemsManager = true,
     useDefaultCredentialsProvider = false,
-    tunnelTarget = None
+    tunnelTarget = None,
+    rdsTunnelTarget = None
   )
 }
 
@@ -116,13 +118,5 @@ case object SismOldest extends SingleInstanceSelectionMode
 case object SismUnspecified extends SingleInstanceSelectionMode
 
 sealed trait TunnelTarget
-case class TunnelTargetWithHostName(
-  localPort: Int,
-  remoteHostName: String,
-  remotePort: Int,
-) extends TunnelTarget
-case class TunnelTargetWithTags(
-  localPort: Int,
-  remoteTags: Seq[String],
-  remotePort: Int,
-) extends TunnelTarget
+case class TunnelTargetWithHostName(localPort: Int, remoteHostName: String, remotePort: Int) extends TunnelTarget
+case class TunnelTargetWithRDSTags(localPort: Int, remoteTags: Seq[String]) extends TunnelTarget

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -10,6 +10,8 @@ case class InstanceId(id: String) extends AnyVal
 case class Instance(id: InstanceId, publicDomainNameOpt: Option[String], publicIpAddressOpt: Option[String], privateIpAddress: String, launchInstant: Instant)
 case class AppStackStage(app: String, stack: String, stage: String)
 case class ExecutionTarget(instances: Option[List[InstanceId]] = None, tagValues: Option[List[String]] = None)
+case class RDSInstanceId(id: String) extends AnyVal
+case class RDSInstance(id: RDSInstanceId, hostname: String, port: Int)
 
 case class Arguments(
   verbose: Boolean,

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -33,7 +33,8 @@ case class Arguments(
   sourceFile: Option[String],
   targetFile: Option[String],
   tunnelThroughSystemsManager: Boolean,
-  useDefaultCredentialsProvider: Boolean
+  useDefaultCredentialsProvider: Boolean,
+  tunnelTarget: Option[TunnelTarget]
 )
 
 object Arguments {
@@ -63,7 +64,8 @@ object Arguments {
     sourceFile = None,
     targetFile = None,
     tunnelThroughSystemsManager = true,
-    useDefaultCredentialsProvider = false
+    useDefaultCredentialsProvider = false,
+    tunnelTarget = None
   )
 }
 
@@ -108,3 +110,15 @@ sealed trait SingleInstanceSelectionMode
 case object SismNewest extends SingleInstanceSelectionMode
 case object SismOldest extends SingleInstanceSelectionMode
 case object SismUnspecified extends SingleInstanceSelectionMode
+
+sealed trait TunnelTarget
+case class TunnelTargetWithHostName(
+  localPort: Int,
+  remoteHostName: String,
+  remotePort: Int,
+) extends TunnelTarget
+case class TunnelTargetWithTags(
+  localPort: Int,
+  remoteTags: Seq[String],
+  remotePort: Int,
+) extends TunnelTarget

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -118,5 +118,5 @@ case object SismOldest extends SingleInstanceSelectionMode
 case object SismUnspecified extends SingleInstanceSelectionMode
 
 sealed trait TunnelTarget
-case class TunnelTargetWithHostName(localPort: Int, remoteHostName: String, remotePort: Int) extends TunnelTarget
 case class TunnelTargetWithRDSTags(localPort: Int, remoteTags: Seq[String]) extends TunnelTarget
+case class TunnelTargetWithHostName(localPort: Int, remoteHostName: String, remotePort: Int) extends TunnelTarget

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsync
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
 import java.time.Instant
+import com.amazonaws.services.rds.AmazonRDSAsync
 
 case class InstanceId(id: String) extends AnyVal
 case class Instance(id: InstanceId, publicDomainNameOpt: Option[String], publicIpAddressOpt: Option[String], privateIpAddress: String, launchInstant: Instant)
@@ -100,7 +101,8 @@ case class SSMConfig (
 case class AWSClients (
   ssmClient: AWSSimpleSystemsManagementAsync,
   stsClient: AWSSecurityTokenServiceAsync,
-  ec2Client: AmazonEC2Async
+  ec2Client: AmazonEC2Async,
+  rdsClient: AmazonRDSAsync
 )
 
 case class ResultsWithInstancesNotFound(

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -119,4 +119,4 @@ case object SismUnspecified extends SingleInstanceSelectionMode
 
 sealed trait TunnelTarget
 case class TunnelTargetWithRDSTags(localPort: Int, remoteTags: Seq[String]) extends TunnelTarget
-case class TunnelTargetWithHostName(localPort: Int, remoteHostName: String, remotePort: Int) extends TunnelTarget
+case class TunnelTargetWithHostName(localPort: Int, remoteHostName: String, remotePort: Int, remoteTags: Seq[String] = Seq.empty) extends TunnelTarget

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -34,18 +34,22 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
       extractTunnelConfig(s"5432:$hostname:5432") shouldBe expected
     }
 
-    "extracts tunnel config given ports and tags" in {
-      val expected = Right(TunnelTargetWithTags(5432, List("APP", "STACK", "STAGE"), 5432))
-      extractTunnelConfig(s"5432:APP,STACK,STAGE:5432") shouldBe expected
-    }
-
-    "returns error if no tags are given" in {
-      extractTunnelConfig(s"5432:,:5432").isLeft shouldBe true
-    }
-
     "returns error if ports are not integers" in {
       extractTunnelConfig(s"5432i:$hostname:5432").isLeft shouldBe true
       extractTunnelConfig(s"5432:$hostname:5432i").isLeft shouldBe true
+    }
+  }
+
+  "extractRDSTunnelConfig" - {
+    import Logic.extractRDSTunnelConfig
+
+    "extracts tunnel config given ports and tags" in {
+      val expected = Right(TunnelTargetWithRDSTags(5432, List("APP", "STACK", "STAGE")))
+      extractRDSTunnelConfig(s"5432:APP,STACK,STAGE") shouldBe expected
+    }
+
+    "returns error if no tags are given" in {
+      extractRDSTunnelConfig(s"5432:,").isLeft shouldBe true
     }
   }
 

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -11,8 +11,8 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
     import Logic.extractSASTags
 
     "extracts stack app and stage from valid input" in {
-      val expected = List("app", "stack", "stage")
-      extractSASTags(Seq("app", "stack", "stage")).right.value shouldEqual expected
+      val expected = Right(List("app", "stack", "stage"))
+      extractSASTags(Seq("app", "stack", "stage")) shouldEqual expected
     }
 
     "provides error if nothing is provided" in {
@@ -74,17 +74,17 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
     "Given one instance" - {
       "If single instance selection mode is SismNewest, returns argument" in {
         val i = makeInstance("X", Some("127.0.0.1"), "10.1.1.10", 0)
-        getSSHInstance(List(i), SismNewest).right.get shouldEqual i
+        getSSHInstance(List(i), SismNewest).value shouldEqual i
       }
 
       "If single instance selection mode is SismOldest, returns argument" in {
         val i = makeInstance("X", Some("127.0.0.1"), "10.1.1.10", 0)
-        getSSHInstance(List(i), SismOldest).right.get shouldEqual i
+        getSSHInstance(List(i), SismOldest).value shouldEqual i
       }
 
       "If single instance selection mode is SismUnspecified, returns argument" in {
         val i = makeInstance("X", Some("127.0.0.1"), "10.1.1.10", 0)
-        getSSHInstance(List(i), SismUnspecified).right.get shouldEqual i
+        getSSHInstance(List(i), SismUnspecified).value shouldEqual i
       }
     }
 
@@ -94,11 +94,11 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
       val i3 = makeInstance("Z", Some("127.0.0.1"), "10.1.1.10", 0)
 
       "If single instance selection mode is SismNewest, selects the newest instance with public IP" in {
-        getSSHInstance(List(i1, i2, i3), SismNewest).right.get shouldEqual i3
+        getSSHInstance(List(i1, i2, i3), SismNewest).value shouldEqual i3
       }
 
       "If single instance selection mode is SismOldest, selects the oldest instance with public IP" in {
-        getSSHInstance(List(i1, i2, i3), SismOldest).right.get shouldEqual i1
+        getSSHInstance(List(i1, i2, i3), SismOldest).value shouldEqual i1
       }
 
       "If single instance selection mode is SismUnspecified, should be Left" in {
@@ -121,29 +121,29 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
     "specifying we want private IP" - {
       "return private if only private exists" in {
         val result = getAddress(instanceWithPrivateIpOnly, onlyUsePrivateIP = true)
-        result.right.value shouldEqual "10.1.1.10"
+        result.value shouldEqual "10.1.1.10"
       }
 
       "return private if public and private exists" in {
         val result = getAddress(instanceWithPublicIpAndPrivateIp, onlyUsePrivateIP = true)
-        result.right.value shouldEqual "10.1.1.10"
+        result.value shouldEqual "10.1.1.10"
       }
     }
 
     "not specifying we want private IP" - {
       "return public if it exists" in {
         val result = getAddress(instanceWithPublicIpAndPrivateIp, onlyUsePrivateIP = false)
-        result.right.value shouldEqual "34.1.1.10"
+        result.value shouldEqual "34.1.1.10"
       }
 
       "return private if no public and no dns" in {
         val result = getAddress(instanceWithPrivateIpOnly, onlyUsePrivateIP = false)
-        result.right.value shouldEqual "10.1.1.10"
+        result.value shouldEqual "10.1.1.10"
       }
 
       "return public IP if it exists, even if public DNS exists" in {
         val result = getAddress(instanceWithPublicDnsAndPublicIPAndPrivateIp, onlyUsePrivateIP = false)
-        result.right.value shouldEqual "34.1.1.10"
+        result.value shouldEqual "34.1.1.10"
       }
     }
   }
@@ -163,12 +163,12 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
 
       "return the host key using the first algorithm when there is a match" in {
         val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "", true)), List("ecdsa-sha2-nistp256", "ssh-rsa"))
-        hostKey.right.value shouldBe "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKDHXJ6sXLoKprcNzMDLF6YVroaf5ycshemnS1TJggIA6cf/FW5EmdzUlf+P0QfBdLsqjBVBxQhyWTtHXD4Byds= root@ip-10-248-50-51"
+        hostKey.value shouldBe "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKDHXJ6sXLoKprcNzMDLF6YVroaf5ycshemnS1TJggIA6cf/FW5EmdzUlf+P0QfBdLsqjBVBxQhyWTtHXD4Byds= root@ip-10-248-50-51"
       }
 
       "return the host key using the second algorithm when there is a match for the first" in {
         val hostKey = Logic.getHostKeyEntry(Right(CommandResult(results, "", true)), List("ecdsa-idontexist", "ssh-rsa"))
-        hostKey.right.value shouldBe "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgfV3YLgQ6PKhz3NHwFOhQA1ZgBBxYq9duNF0RdHezuBDQAdz51UKssvsIBi74/DuHk7RjaPPMZaC6yNkAuRMTyJk82S93GGow36iMTQD4HTpDuUFloT+SiTrjez/mkS2Wk+fm4brhjo9Xb8M3TXpOn65AXC/3mrB8JrZwx5Y9d2IwEQT1/r6aM1mUo2JJrSQJ1zv+3+ZFKfij1UncjG7rXsUegmR0lmt8bfAkpef1I+LK3CERgxRNCcuM80ptTws3vgxyP9cS60IiF7W1lwuwtvDvZ9LuDnHlrMi+t1t5EvwRm1CE9eLw9+qTQQijBFVjZlXT03St/6IJLMvBazI7 root@ip-10-248-50-51"
+        hostKey.value shouldBe "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgfV3YLgQ6PKhz3NHwFOhQA1ZgBBxYq9duNF0RdHezuBDQAdz51UKssvsIBi74/DuHk7RjaPPMZaC6yNkAuRMTyJk82S93GGow36iMTQD4HTpDuUFloT+SiTrjez/mkS2Wk+fm4brhjo9Xb8M3TXpOn65AXC/3mrB8JrZwx5Y9d2IwEQT1/r6aM1mUo2JJrSQJ1zv+3+ZFKfij1UncjG7rXsUegmR0lmt8bfAkpef1I+LK3CERgxRNCcuM80ptTws3vgxyP9cS60IiF7W1lwuwtvDvZ9LuDnHlrMi+t1t5EvwRm1CE9eLw9+qTQQijBFVjZlXT03St/6IJLMvBazI7 root@ip-10-248-50-51"
       }
 
       "error when there are no suitable host keys" in {

--- a/src/test/scala/com/gu/ssm/LogicTest.scala
+++ b/src/test/scala/com/gu/ssm/LogicTest.scala
@@ -24,6 +24,31 @@ class LogicTest extends AnyFreeSpec with Matchers with EitherValues {
     }
   }
 
+  "extractTunnelConfig" - {
+    import Logic.extractTunnelConfig
+
+    val hostname = "example-db.rds.amazonaws.com"
+
+    "extracts tunnel config given ports and hostname" in {
+      val expected = Right(TunnelTargetWithHostName(5432, hostname, 5432))
+      extractTunnelConfig(s"5432:$hostname:5432") shouldBe expected
+    }
+
+    "extracts tunnel config given ports and tags" in {
+      val expected = Right(TunnelTargetWithTags(5432, List("APP", "STACK", "STAGE"), 5432))
+      extractTunnelConfig(s"5432:APP,STACK,STAGE:5432") shouldBe expected
+    }
+
+    "returns error if no tags are given" in {
+      extractTunnelConfig(s"5432:,:5432").isLeft shouldBe true
+    }
+
+    "returns error if ports are not integers" in {
+      extractTunnelConfig(s"5432i:$hostname:5432").isLeft shouldBe true
+      extractTunnelConfig(s"5432:$hostname:5432i").isLeft shouldBe true
+    }
+  }
+
   "generateScript" - {
     import Logic.generateScript
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -67,48 +67,55 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
       val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+        val (instanceId, _) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
         instanceId.id shouldEqual "raspberry"
       }
 
       "user command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10;"""))
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
           command should contain (Out("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10;"""))
         }
       }
 
       "machine command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
           command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false)
+          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
           command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
         }
       }
 
       "ssm tunnel" - {
         "is correctly formed" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = true)
+          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = true, tunnelTarget = None)
           command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10""")
+        }
+      }
+
+      "ssh tunnel to remote host" - {
+        "is correctly formed" in {
+          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = true, tunnelTarget = Some(TunnelTargetWithHostName(5000, "example-hostname.com", 5432)))
+          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10 -L 5000:example-hostname.com:5432""")
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -115,7 +115,7 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
       "ssh tunnel to remote host" - {
         "is correctly formed" in {
           val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = true, tunnelTarget = Some(TunnelTargetWithHostName(5000, "example-hostname.com", 5432)))
-          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10 -L 5000:example-hostname.com:5432""")
+          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10 -L 5000:example-hostname.com:5432 -N -f""")
         }
       }
     }


### PR DESCRIPTION
## What does this change?

Adds two options to enable SSH tunnelling. They're mutually exclusive.

The first, `--tunnel localPort:hostname:remotePort`, allows the user to specify an arbitrary hostname and remote port.
The second, `--rds-tunnel localPort:list,of,tags`, allows the user to specify a local port, and a list of tags. SSM looks up an RDS instance via the tags, failing if there are 0 or many instances.

## What is the value of this?

Across our estate, we have many scripts that accomplish this in a few different ways – here are [a few examples,](https://github.com/search?q=org%3Aguardian+path%3Assh-tunnel&type=code) and I suspect there are more. These commands aim to replace most of them with a one-liner that can be included in project README files and used directly.

## Any additional notes?

There are a few decisions here that gave me pause. One concerns the interface.

~When using -x to run the command immediately, there's no output to affirm that the **correct hostname has been chosen** (important with a tag lookup, or to aid debugging of any sort), or to e.g. **warn the user when connecting to resources with a `PROD` tag.** I've spent some time looking but do not yet understand how this program pipes output to the shell – to me, both these features are dealbreakers, and I'd be delighted to pair with somebody who did know how we might accomplish this.~

This is now added. (To cover the unknown above, the script adds its output by piping directly to the shell via a wrapper script – see https://github.com/guardian/ssm-scala/pull/61.) Example output tunnelling to a DB with PROD tags:

```
# If the command succeeded, a tunnel has been established.
# Local port: 5432
# Remote address: typerighter-rule-manager-store-prod.cbyyqud0gzor.eu-west-1.rds.amazonaws.com:5432
# The tags indicate that this is a PRODUCTION resource. Please take care! Perhaps bring a pair?
```

Unlike other ssh commands, this output does still appear when `--raw` is specified. As it goes to stderr via `Metadata`, it doesn't interfere when parsed out with `eval`, so I hope that's fine.

There were also a few modelling decisions:

- I went between a few options in modelling these values, and settled on two case classes, `TunnelTargetWithRDSTags` and  `TunnelTargetWithHostName`, where the former resolves into the latter as the program executes.
- We carry through two optional parameters in the `Arguments` case class, rather than one. I felt it was neater with one, but having two allows us to fail when both options are specified via `checkConfig`.