### PR TITLE
Migrate to scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12"
+scalaVersion := "3.3.1"
 
 name := "ssm-scala"
 organization := "com.gu"

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -44,7 +44,7 @@ case class Arguments(
 object Arguments {
   val targetInstanceDefaultUser = "ubuntu"
   val bastionDefaultUser = "ubuntu"
-  val defaultHostKeyAlgPreference = List("ecdsa-sha2-nistp256", "ssh-rsa")
+  val defaultHostKeyAlgPreference: List[String] = List("ecdsa-sha2-nistp256", "ssh-rsa")
 
   def empty(): Arguments = Arguments(
     verbose = false,

--- a/src/main/scala/com/gu/ssm/utils/attempt/Failure.scala
+++ b/src/main/scala/com/gu/ssm/utils/attempt/Failure.scala
@@ -21,7 +21,7 @@ case class Failure(
   context: Option[String] = None,
   throwable: Option[Throwable] = None
 ) {
-  def attempt = FailedAttempt(this)
+  def attempt: FailedAttempt = FailedAttempt(this)
 }
 object Failure {
   def apply(message: String,


### PR DESCRIPTION
## What does this change?
This PR upgrades ssm-scala onto to scala 3. 

This is my first scala 3 upgrade so I'm by no means an expert, I simply ran the 4 commands outline in the migration plugin https://github.com/scalacenter/scala3-migrate and there were very few changes.

I've tested this locally using both sbt console and the generated executable from `./generate-executable.sh`

## What is the value of this?
I'm not sure - maybe some performance improvements.
