### PR TITLE
Bump version number to 3.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion := "2.13.12"
 
 name := "ssm-scala"
 organization := "com.gu"
-version := "2.4.0"
+version := "3.4.0"
 
 val awsSdkVersion = "1.12.627"
 


### PR DESCRIPTION
## What does this change?
For a new release of ssm-scala, containing this change https://github.com/guardian/ssm-scala/pull/375

My motivation for a major version bump is that technically the changes in #375 are not backwards compatible - whilst anyone using `--raw` or `-x` will not be affected, anyone relying on the output with neither of those flags set will now get a new result. 