### PR TITLE
Add `--help` option

### DIFF
--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -11,6 +11,8 @@ object ArgumentParser {
 
   val argParser: OptionParser[Arguments] = new OptionParser[Arguments]("ssm") {
 
+    help("help").text("prints this usage text")
+
     opt[String]('p', "profile").optional()
       .action { (profile, args) =>
         args.copy(profile = Some(profile))


### PR DESCRIPTION
## What does this change?

scopt has a special option with a predefined action called help("help"). When help("help") is defined, parser will print out a short error message when it fails instead of printing the entire usage text.

This is useful, because the existing behaviour is to display the short error message and then the long usage text, which masks the helpful error message.

## What is the value of this?

Less scrolling required to see the helpful error message when you make a mistake running `ssm`