### PR TITLE
Bump version to v3.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion := "3.3.1"
 
 name := "ssm-scala"
 organization := "com.gu"
-version := "3.4.0"
+version := "3.5.0"
 
 val awsSdkVersion = "1.12.646"
 

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SCALA_FOLDER="scala-2.13"
+SCALA_FOLDER="scala-3.3.1"
 cd $DIR
 sbt assembly
 cat "$DIR/generate-executable-prefix" "$DIR/target/$SCALA_FOLDER/ssm.jar" > "$DIR/target/$SCALA_FOLDER/ssm"


### PR DESCRIPTION
## What does this change?
Bumps the version number of ssm-scala in order to release https://github.com/guardian/ssm-scala/pull/378

