### PR TITLE
Feat: target a specific java version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,5 +28,9 @@ assemblyMergeStrategy := {
 }
 assemblyJarName := "ssm.jar"
 
-scalacOptions := Seq("-unchecked", "-deprecation")
+scalacOptions := Seq(
+  "-unchecked",
+  "-deprecation",
+  "-release:11",
+)
 


### PR DESCRIPTION
## What does this change?

Adds the scala option to target a specific version of the jvm (v11).