### PR TITLE
dependabot.yml to bump monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## What does this change?

switches from weekly GHA updates to monthly

## What is the value of this?

The project is not active enough for weekly dependency bumps to be useful. Reduces workload on a small team. Dependabot has a different process for raising PRs in response to vulnerability disclosures, so this will not affect our response time to new vulnerabilities.
