### PR TITLE
Install sbt in CI

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           java-version: '21'
           distribution: 'adopt'
+      - uses: sbt/setup-sbt@646c82cdb36e794ff9ab674b60242d80d96910df # v1.1.1
       - run: sbt test


### PR DESCRIPTION


## What does this change?
sbt is no longer available on Github's test runners, so we need to explicitly install it.


## What is the value of this?

This will mean CI works again!
