### PR TITLE
Update the Scala version in the generate executable script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
-scalaVersion := "3.3.4"
-
 name := "ssm-scala"
 organization := "com.gu"
 version := "3.5.0"
+
+// be sure to also update this in the `generate-executable.sh` script
+scalaVersion := "3.3.4"
 
 val awsSdkVersion = "1.12.729"
 

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SCALA_FOLDER="scala-3.3.1"
+SCALA_FOLDER="scala-3.3.4"
 cd $DIR
 sbt assembly
 cat "$DIR/generate-executable-prefix" "$DIR/target/$SCALA_FOLDER/ssm.jar" > "$DIR/target/$SCALA_FOLDER/ssm"


### PR DESCRIPTION

## What does this change?

Since this script includes the hard-coded Scala version, it is essential that this is kept in sync with the Scala version defined in the build.sbt file. We might consider automating this coupling away, but for now I've fixed the reference and added a comment to the build.sbt file so it is less likely these versions drift apart in the future.


## What is the value of this?

The generate-executable script is part of the release process, so this ensures that the program can be released.


## Any additional notes?

If this becomes tedious in the future then we can automatically extract the scala version from the build.sbt file, or by inspecting the filesystem structure.