### PR TITLE
Simplify GitHub Actions workflows

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -10,10 +10,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Java 21
-        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
-        with:
-          java-version: '21'
-          distribution: 'adopt'
-      - uses: sbt/setup-sbt@50a38cca700907fb9df65ecabcefb85ebaa424a7 # v1.1.4
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
       - run: sbt test

--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -3,23 +3,16 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21


### PR DESCRIPTION
Replaces #452 #453 #454

## What does this change?

We now use our own setup-scala workflow, instead of having to set up Java and sbt separately. This requires that we specify a java version in our `.tool-versions` file.

Note: We're only specifying the major Java version so that we aren't providing irrelevant minor and patch versions that will drift out of date over time. This is not supported by `asdf`, but switching to [mise](https://mise.jdx.dev/) will work as a drop-in replacement.



## What is the value of this?

This will reduce the number of PRs that land on this project in the future.


## Any additional notes?

We also bump the actions/checkout version to consolidate the GHA changes.