### PR TITLE
fix ssm --help command

### DIFF
--- a/generate-executable-prefix
+++ b/generate-executable-prefix
@@ -12,6 +12,7 @@ for param in $@; do
   test "$param" = "--dryrun" && EXECUTE_FLAG=0
   # raw mode makes no sense if immediately executing the command
   test "$param" = "--raw" && EXECUTE_FLAG=0
+  test "$param" = "--help" && EXECUTE_FLAG=0
 done
 
 if (test $EXECUTE_FLAG -eq 0); then


### PR DESCRIPTION
This PR fixes the `ssm --help` command.

The default mode has changed to -x for most cases (see https://github.com/guardian/ssm-scala/pull/375 ).  However this only makes sense in some cases and not when you use --help.

This PR adds it so that --help is also excluded from the auto-execute behaviour.

Before (broken)
```
% ssm --help                
bash: Usage:: command not found
bash: repl: command not found
bash: args: No such file or directory
usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface] [-b bind_address]
           [-c cipher_spec] [-D [bind_address:]port] [-E log_file]
           [-e escape_char] [-F configfile] [-I pkcs11] [-i identity_file]
           [-J destination] [-L address] [-l login_name] [-m mac_spec]
           [-O ctl_cmd] [-o option] [-P tag] [-p port] [-R address]
           [-S ctl_path] [-W host:port] [-w local_tun[:remote_tun]]
           destination [command [argument ...]]
       ssh [-Q query_option]
bash: line 2: --help: command not found
bash: line 3: value: No such file or directory
bash: -c: line 4: syntax error near unexpected token `('
bash: -c: line 4: `  -i, --instances <value>  Specify the instance ID(s) on which the specified command(s) should execute'
```

however if I do ssm --raw --help it seems ok
```
% ssm --raw --help
Error: Unknown option --raw
Usage: ssm [cmd|repl|ssh|scp] [options] <args>...

  --help                   prints this usage text
..........etc............
```

Afterwards we shouldn't need the --raw