### PR TITLE
Scalafmt and compiler warning fixes

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = 3.8.5
+runner.dialect = scala3

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SCALA_FOLDER="scala-3.6.2"
+SCALA_FOLDER="scala-3.6.3"
 cd $DIR
 sbt assembly
 cat "$DIR/generate-executable-prefix" "$DIR/target/$SCALA_FOLDER/ssm.jar" > "$DIR/target/$SCALA_FOLDER/ssm"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -3,9 +3,12 @@ package com.gu.ssm
 import java.io.File
 
 import com.amazonaws.regions.{Region, Regions}
-import com.gu.ssm.Arguments.{targetInstanceDefaultUser, bastionDefaultUser, defaultHostKeyAlgPreference}
+import com.gu.ssm.Arguments.{
+  targetInstanceDefaultUser,
+  bastionDefaultUser,
+  defaultHostKeyAlgPreference
+}
 import scopt.OptionParser
-
 
 object ArgumentParser {
 
@@ -13,31 +16,46 @@ object ArgumentParser {
 
     help("help").text("prints this usage text")
 
-    opt[String]('p', "profile").optional()
+    opt[String]('p', "profile")
+      .optional()
       .action { (profile, args) =>
         args.copy(profile = Some(profile))
-      } text "The AWS profile name to use for authenticating this execution"
+      }
+      .text("The AWS profile name to use for authenticating this execution")
 
     opt[Seq[String]]('i', "instances")
       .action { (instanceIds, args) =>
         val instances = instanceIds.map(i => InstanceId(i)).toList
-        args.copy(executionTarget = Some(ExecutionTarget(instances = Some(instances))))
-      } text "Specify the instance ID(s) on which the specified command(s) should execute"
+        args.copy(executionTarget =
+          Some(ExecutionTarget(instances = Some(instances)))
+        )
+      }
+      .text(
+        "Specify the instance ID(s) on which the specified command(s) should execute"
+      )
 
     opt[Seq[String]]('t', "tags")
       .validate { tagsStr =>
         Logic.extractSASTags(tagsStr).map(_ => ())
       }
       .action { (tagsStr, args) =>
-        Logic.extractSASTags(tagsStr)
+        Logic
+          .extractSASTags(tagsStr)
           .fold(
             _ => args,
-            tagValues => args.copy(executionTarget = Some(ExecutionTarget(tagValues = Some(tagValues))))
+            tagValues =>
+              args.copy(executionTarget =
+                Some(ExecutionTarget(tagValues = Some(tagValues)))
+              )
           )
-      } text "Search for instances by tag. If you provide less than 3 tags assumed order is app,stage,stack." +
-      " e.g. '--tags riff-raff,prod' or '--tags grafana' Upper/lowercase variations will be tried."
+      }
+      .text(
+        "Search for instances by tag. If you provide less than 3 tags assumed order is app,stage,stack." +
+          " e.g. '--tags riff-raff,prod' or '--tags grafana' Upper/lowercase variations will be tried."
+      )
 
-    opt[String]('r', "region").optional()
+    opt[String]('r', "region")
+      .optional()
       .validate { region =>
         try {
           Region.getRegion(Regions.fromName(region))
@@ -46,30 +64,45 @@ object ArgumentParser {
           case _: IllegalArgumentException =>
             failure(s"Invalid AWS region name, $region")
         }
-      } action { (region, args) =>
-      args.copy(region = Region.getRegion(Regions.fromName(region)))
-    } text "AWS region name (defaults to eu-west-1)"
+      }
+      .action { (region, args) =>
+        args.copy(region = Region.getRegion(Regions.fromName(region)))
+      }
+      .text("AWS region name (defaults to eu-west-1)")
 
-    opt[Unit]("verbose").action( (_, c) =>
-      c.copy(verbose = true) ).text("enable more verbose logging")
+    opt[Unit]("verbose")
+      .action((_, c) => c.copy(verbose = true))
+      .text("enable more verbose logging")
 
-    opt[Unit]("use-default-credentials-provider").optional()
+    opt[Unit]("use-default-credentials-provider")
+      .optional()
       .action((value, args) => args.copy(useDefaultCredentialsProvider = true))
-      .text("Use the default AWS credentials provider chain rather than profile credentials. " +
-            "This option is required when running within AWS itself.")
+      .text(
+        "Use the default AWS credentials provider chain rather than profile credentials. " +
+          "This option is required when running within AWS itself."
+      )
 
     cmd("cmd")
       .action((_, c) => c.copy(mode = Some(SsmCmd)))
-      .text("Execute a single (bash) command, or a file containing bash commands")
+      .text(
+        "Execute a single (bash) command, or a file containing bash commands"
+      )
       .children(
-        opt[String]('u', "user").optional()
+        opt[String]('u', "user")
+          .optional()
           .action((user, args) => args.copy(targetInstanceUser = Some(user)))
-          .text(s"Execute command on remote host as this user (default: $targetInstanceDefaultUser)"),
-        opt[String]('c', "cmd").optional()
+          .text(
+            s"Execute command on remote host as this user (default: $targetInstanceDefaultUser)"
+          ),
+        opt[String]('c', "cmd")
+          .optional()
           .action((cmd, args) => args.copy(toExecute = Some(cmd)))
           .text("A bash command to execute"),
-        opt[File]('f', "file").optional()
-          .action((file, args) => args.copy(toExecute = Some(Logic.generateScript(Right(file)))))
+        opt[File]('f', "file")
+          .optional()
+          .action((file, args) =>
+            args.copy(toExecute = Some(Logic.generateScript(Right(file))))
+          )
           .text("A file containing bash commands to execute")
       )
 
@@ -77,196 +110,301 @@ object ArgumentParser {
       .action((_, c) => c.copy(mode = Some(SsmSsh)))
       .text("Create and upload a temporary ssh key")
       .children(
-        opt[String]('u', "user").optional()
+        opt[String]('u', "user")
+          .optional()
           .action((user, args) => args.copy(targetInstanceUser = Some(user)))
-          .text(s"Connect to remote host as this user (default: $targetInstanceDefaultUser)"),
-        opt[Int]("port").optional()
-          .action((port, args) => args.copy(targetInstancePortNumber = Some(port)))
+          .text(
+            s"Connect to remote host as this user (default: $targetInstanceDefaultUser)"
+          ),
+        opt[Int]("port")
+          .optional()
+          .action((port, args) =>
+            args.copy(targetInstancePortNumber = Some(port))
+          )
           .text(s"Connect to remote host on this port"),
-        opt[Unit]("newest").optional()
+        opt[Unit]("newest")
+          .optional()
           .action((_, args) => {
             args.copy(
               singleInstanceSelectionMode = SismNewest,
-              isSelectionModeNewest = true)
+              isSelectionModeNewest = true
+            )
           })
-          .text("Selects the newest instance if more than one instance was specified"),
-        opt[Unit]("oldest").optional()
+          .text(
+            "Selects the newest instance if more than one instance was specified"
+          ),
+        opt[Unit]("oldest")
+          .optional()
           .action((_, args) => {
             args.copy(
               singleInstanceSelectionMode = SismOldest,
-              isSelectionModeOldest = true)
+              isSelectionModeOldest = true
+            )
           })
-          .text("Selects the oldest instance if more than one instance was specified"),
-        opt[Unit]("private").optional()
+          .text(
+            "Selects the oldest instance if more than one instance was specified"
+          ),
+        opt[Unit]("private")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              usePrivateIpAddress = true)
+            args.copy(usePrivateIpAddress = true)
           })
           .text("Use private IP address (must be routable via VPN Gateway)"),
-        opt[Unit]("raw").optional()
+        opt[Unit]("raw")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              rawOutput = true)
+            args.copy(rawOutput = true)
           })
-          .text("Unix pipe-able ssh connection string. Note: disables automatic execution. You must use 'eval' to execute this due to nested quoting"),
-        opt[Unit]('x', "execute").optional()
+          .text(
+            "Unix pipe-able ssh connection string. Note: disables automatic execution. You must use 'eval' to execute this due to nested quoting"
+          ),
+        opt[Unit]('x', "execute")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              rawOutput = true)
+            args.copy(rawOutput = true)
           })
-          .text("[Deprecated - new default behaviour] Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"),
-        opt[Unit]('d', "dryrun").optional()
+          .text(
+            "[Deprecated - new default behaviour] Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"
+          ),
+        opt[Unit]('d', "dryrun")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              rawOutput = false)
+            args.copy(rawOutput = false)
           })
-          .text("Generate SSH command but do not execute (previous default behaviour)"),
-        opt[Unit]('A', "agent").optional()
+          .text(
+            "Generate SSH command but do not execute (previous default behaviour)"
+          ),
+        opt[Unit]('A', "agent")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              useAgent = Some(true))
+            args.copy(useAgent = Some(true))
           })
-          .text("Use the local ssh agent to register the private key (and do not use -i); only bastion connections"),
-        opt[Unit]('a', "no-agent").optional()
+          .text(
+            "Use the local ssh agent to register the private key (and do not use -i); only bastion connections"
+          ),
+        opt[Unit]('a', "no-agent")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              useAgent = Some(false))
+            args.copy(useAgent = Some(false))
           })
           .text("Do not use the local ssh agent"),
-        opt[String]('b', "bastion").optional()
+        opt[String]('b', "bastion")
+          .optional()
           .action((bastion, args) => {
             args
-              .copy(bastionInstance = Some(ExecutionTarget(Some(List(InstanceId(bastion))), None)))
+              .copy(bastionInstance =
+                Some(ExecutionTarget(Some(List(InstanceId(bastion))), None))
+              )
           })
-          .text(s"Connect through the given bastion specified by its instance id; implies -A (use agent) unless followed by -a."),
-        opt[Seq[String]]('B', "bastion-tags").optional()
+          .text(
+            s"Connect through the given bastion specified by its instance id; implies -A (use agent) unless followed by -a."
+          ),
+        opt[Seq[String]]('B', "bastion-tags")
+          .optional()
           .validate { tagsStr =>
             Logic.extractSASTags(tagsStr).map(_ => ())
           }
           .action { (tagsStr, args) =>
-            Logic.extractSASTags(tagsStr)
+            Logic
+              .extractSASTags(tagsStr)
               .fold(
                 _ => args,
                 tagValues => {
                   args
-                    .copy(bastionInstance = Some(ExecutionTarget(None, Some(tagValues))))
+                    .copy(bastionInstance =
+                      Some(ExecutionTarget(None, Some(tagValues)))
+                    )
                 }
               )
-          } text(s"Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A."),
-        opt[Int]("bastion-port").optional()
-          .action((bastionPortNumber, args) => args.copy(bastionPortNumber = Some(bastionPortNumber)))
+          }
+          .text(
+            s"Connect through the given bastion identified by its tags; implies -a (use agent) unless followed by -A."
+          ),
+        opt[Int]("bastion-port")
+          .optional()
+          .action((bastionPortNumber, args) =>
+            args.copy(bastionPortNumber = Some(bastionPortNumber))
+          )
           .text(s"Connect through the given bastion at a given port. "),
-        opt[String]("bastion-user").optional()
-          .action((bastionUser, args) => args.copy(bastionUser = Some(bastionUser)))
-          .text(s"Connect to bastion as this user (default: $bastionDefaultUser). "),
-        opt[String]("host-key-alg-preference").optional().unbounded()
-          .action((alg, args) => args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference))
-          .text(s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"),
-        opt[Unit]("ssm-tunnel").optional()
+        opt[String]("bastion-user")
+          .optional()
+          .action((bastionUser, args) =>
+            args.copy(bastionUser = Some(bastionUser))
+          )
+          .text(
+            s"Connect to bastion as this user (default: $bastionDefaultUser). "
+          ),
+        opt[String]("host-key-alg-preference")
+          .optional()
+          .unbounded()
+          .action((alg, args) =>
+            args.copy(hostKeyAlgPreference = alg :: args.hostKeyAlgPreference)
+          )
+          .text(
+            s"The preferred host key algorithms, can be specified multiple times - last is preferred (default: ${defaultHostKeyAlgPreference.mkString(", ")})"
+          ),
+        opt[Unit]("ssm-tunnel")
+          .optional()
           .text("[deprecated]"),
-        opt[Unit]("no-ssm-proxy").optional()
+        opt[Unit]("no-ssm-proxy")
+          .optional()
           .action((_, args) => args.copy(tunnelThroughSystemsManager = false))
-          .text("Do not connect to the host proxying via AWS Systems Manager - go direct to port 22. Useful for  instances running old versions of systems manager (< 2.3.672.0)"),
-        opt[String]("tunnel").optional()
+          .text(
+            "Do not connect to the host proxying via AWS Systems Manager - go direct to port 22. Useful for  instances running old versions of systems manager (< 2.3.672.0)"
+          ),
+        opt[String]("tunnel")
+          .optional()
           .validate { tunnelStr =>
             Logic.extractTunnelConfig(tunnelStr).map(_ => ())
           }
           .action((tunnelStr, args) => {
-            Logic.extractTunnelConfig(tunnelStr)
+            Logic
+              .extractTunnelConfig(tunnelStr)
               .fold(
                 _ => args,
-                tunnelTarget => args.copy(tunnelTarget = Some(tunnelTarget)))
+                tunnelTarget => args.copy(tunnelTarget = Some(tunnelTarget))
+              )
           })
-          .text("Forward traffic from the given local port to the given host and port on the remote side. Accepts the format `localPort:host:remotePort`, " +
-            "e.g. --tunnel 5000:a.remote.host.com:5000"),
-        opt[String]("rds-tunnel").optional()
+          .text(
+            "Forward traffic from the given local port to the given host and port on the remote side. Accepts the format `localPort:host:remotePort`, " +
+              "e.g. --tunnel 5000:a.remote.host.com:5000"
+          ),
+        opt[String]("rds-tunnel")
+          .optional()
           .validate { tunnelStr =>
             Logic.extractRDSTunnelConfig(tunnelStr).map(_ => ())
           }
           .action((tunnelStr, args) => {
-            Logic.extractRDSTunnelConfig(tunnelStr)
+            Logic
+              .extractRDSTunnelConfig(tunnelStr)
               .fold(
                 _ => args,
-                tunnelTarget => args.copy(rdsTunnelTarget = Some(tunnelTarget)))
+                tunnelTarget => args.copy(rdsTunnelTarget = Some(tunnelTarget))
+              )
           })
-          .text("Forward traffic from a given local port to a RDS database specified by tags. Accepts the format `localPort:tags`, where `tags` is a comma-separated list of tag values, " +
-            "e.g. --rds-tunnel 5000:app,stack,stage"),
-        checkConfig( c =>
-          if (c.isSelectionModeOldest && c.isSelectionModeNewest) failure("You cannot both specify --newest and --oldest")
-          else if (c.tunnelTarget.isDefined && c.rdsTunnelTarget.isDefined) failure("You cannot specify both --tunnel and --rdsTunnel")
-          else success )
+          .text(
+            "Forward traffic from a given local port to a RDS database specified by tags. Accepts the format `localPort:tags`, where `tags` is a comma-separated list of tag values, " +
+              "e.g. --rds-tunnel 5000:app,stack,stage"
+          ),
+        checkConfig(c =>
+          if (c.isSelectionModeOldest && c.isSelectionModeNewest)
+            failure("You cannot both specify --newest and --oldest")
+          else if (c.tunnelTarget.isDefined && c.rdsTunnelTarget.isDefined)
+            failure("You cannot specify both --tunnel and --rdsTunnel")
+          else success
+        )
       )
 
     cmd("scp")
       .action((_, c) => c.copy(mode = Some(SsmScp)))
       .text("Secure Copy")
       .children(
-        opt[String]('u', "user").optional()
+        opt[String]('u', "user")
+          .optional()
           .action((user, args) => args.copy(targetInstanceUser = Some(user)))
-          .text(s"Connect to remote host as this user (default: $targetInstanceDefaultUser)"),
-        opt[Int]("port").optional()
-          .action((port, args) => args.copy(targetInstancePortNumber = Some(port)))
+          .text(
+            s"Connect to remote host as this user (default: $targetInstanceDefaultUser)"
+          ),
+        opt[Int]("port")
+          .optional()
+          .action((port, args) =>
+            args.copy(targetInstancePortNumber = Some(port))
+          )
           .text(s"Connect to remote host on this port"),
-        opt[Unit]("newest").optional()
+        opt[Unit]("newest")
+          .optional()
           .action((_, args) => {
             args.copy(
               singleInstanceSelectionMode = SismNewest,
-              isSelectionModeNewest = true)
+              isSelectionModeNewest = true
+            )
           })
-          .text("Selects the newest instance if more than one instance was specified"),
-        opt[Unit]("oldest").optional()
+          .text(
+            "Selects the newest instance if more than one instance was specified"
+          ),
+        opt[Unit]("oldest")
+          .optional()
           .action((_, args) => {
             args.copy(
               singleInstanceSelectionMode = SismOldest,
-              isSelectionModeOldest = true)
+              isSelectionModeOldest = true
+            )
           })
-          .text("Selects the oldest instance if more than one instance was specified"),
-        opt[Unit]("private").optional()
+          .text(
+            "Selects the oldest instance if more than one instance was specified"
+          ),
+        opt[Unit]("private")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              usePrivateIpAddress = true)
+            args.copy(usePrivateIpAddress = true)
           })
           .text("Use private IP address (must be routable via VPN Gateway)"),
-        opt[Unit]("raw").optional()
+        opt[Unit]("raw")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              rawOutput = true)
+            args.copy(rawOutput = true)
           })
           .text("Unix pipe-able scp connection string"),
-        opt[Unit]('x', "execute").optional()
+        opt[Unit]('x', "execute")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              rawOutput = true)
+            args.copy(rawOutput = true)
           })
-          .text("[Deprecated - new default behaviour] Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"),
-        opt[Unit]('d', "dryrun").optional()
+          .text(
+            "[Deprecated - new default behaviour] Makes ssm behave like a single command (eg: `--raw` with automatic piping to the shell)"
+          ),
+        opt[Unit]('d', "dryrun")
+          .optional()
           .action((_, args) => {
-            args.copy(
-              rawOutput = false)
+            args.copy(rawOutput = false)
           })
-          .text("Generate SCP command but do not execute (previous default behaviour)"),
-        opt[Unit]("ssm-tunnel").optional()
+          .text(
+            "Generate SCP command but do not execute (previous default behaviour)"
+          ),
+        opt[Unit]("ssm-tunnel")
+          .optional()
           .text("[deprecated]"),
-        opt[Unit]("no-ssm-proxy").optional()
+        opt[Unit]("no-ssm-proxy")
+          .optional()
           .action((_, args) => args.copy(tunnelThroughSystemsManager = false))
-          .text("Do not connect to the host proxying via AWS Systems Manager - go direct to port 22. Useful for instances running old versions of systems manager (< 2.3.672.0)"),
-
-        arg[String]("[:]<sourceFile>...").required()
-          .action( (sourceFile, args) => args.copy(sourceFile = Some(sourceFile)) )
+          .text(
+            "Do not connect to the host proxying via AWS Systems Manager - go direct to port 22. Useful for instances running old versions of systems manager (< 2.3.672.0)"
+          ),
+        arg[String]("[:]<sourceFile>...")
+          .required()
+          .action((sourceFile, args) =>
+            args.copy(sourceFile = Some(sourceFile))
+          )
           .text("Source file for the scp sub command. See README for details"),
-        arg[String]("[:]<targetFile>...").required()
-          .action( (targetFile, args) => args.copy(targetFile = Some(targetFile)) )
+        arg[String]("[:]<targetFile>...")
+          .required()
+          .action((targetFile, args) =>
+            args.copy(targetFile = Some(targetFile))
+          )
           .text("Target file for the scp sub command. See README for details"),
-        checkConfig( c =>
-          if (c.isSelectionModeOldest && c.isSelectionModeNewest) failure("You cannot both specify --newest and --oldest")
-          else success )
+        checkConfig(c =>
+          if (c.isSelectionModeOldest && c.isSelectionModeNewest)
+            failure("You cannot both specify --newest and --oldest")
+          else success
+        )
       )
 
     checkConfig { args =>
       if (args.mode.isEmpty) Left("You must select a mode to use: cmd or ssh")
-      else if (args.toExecute.isEmpty && args.mode.contains(SsmCmd)) Left("You must provide commands to execute (src-file or cmd)")
-      else if (args.executionTarget.isEmpty) Left("You must provide a list of target instances (-i) or instance App/Stage/Stack tags (-t)")
-      else if (!args.useDefaultCredentialsProvider && args.profile.isEmpty && !System.getenv().containsKey("AWS_PROFILE")) Left("Expected --profile, --use-default-credentials-provider or AWS_PROFILE environment variable")
+      else if (args.toExecute.isEmpty && args.mode.contains(SsmCmd))
+        Left("You must provide commands to execute (src-file or cmd)")
+      else if (args.executionTarget.isEmpty)
+        Left(
+          "You must provide a list of target instances (-i) or instance App/Stage/Stack tags (-t)"
+        )
+      else if (
+        !args.useDefaultCredentialsProvider && args.profile.isEmpty && !System
+          .getenv()
+          .containsKey("AWS_PROFILE")
+      )
+        Left(
+          "Expected --profile, --use-default-credentials-provider or AWS_PROFILE environment variable"
+        )
       else Right(())
     }
   }

--- a/src/main/scala/com/gu/ssm/IO.scala
+++ b/src/main/scala/com/gu/ssm/IO.scala
@@ -10,49 +10,113 @@ import com.gu.ssm.utils.attempt.{ArgumentsError, Attempt, Failure}
 import scala.concurrent.ExecutionContext
 import com.amazonaws.services.rds.AmazonRDSAsync
 
-
 object IO {
-  def resolveInstances(executionTarget: ExecutionTarget, ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
-    executionTarget.instances.map( instances =>
-      EC2.resolveInstanceIds(instances, ec2Client)
-    ).orElse {
-      executionTarget.tagValues.map(EC2.resolveByTags(_, ec2Client))
-    }.getOrElse(Attempt.Left(Failure("Unable to resolve execution target", "You must provide an execution target (instance(s) or tags)", ArgumentsError)))
+  def resolveInstances(
+      executionTarget: ExecutionTarget,
+      ec2Client: AmazonEC2Async
+  )(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
+    executionTarget.instances
+      .map(instances => EC2.resolveInstanceIds(instances, ec2Client))
+      .orElse {
+        executionTarget.tagValues.map(EC2.resolveByTags(_, ec2Client))
+      }
+      .getOrElse(
+        Attempt.Left(
+          Failure(
+            "Unable to resolve execution target",
+            "You must provide an execution target (instance(s) or tags)",
+            ArgumentsError
+          )
+        )
+      )
   }
 
-  def resolveRDSTunnelTarget(target: TunnelTargetWithRDSTags, rdsClient: AmazonRDSAsync)(implicit ec: ExecutionContext): Attempt[TunnelTargetWithHostName] = {
+  def resolveRDSTunnelTarget(
+      target: TunnelTargetWithRDSTags,
+      rdsClient: AmazonRDSAsync
+  )(implicit ec: ExecutionContext): Attempt[TunnelTargetWithHostName] = {
     RDS.resolveByTags(target.remoteTags.toList, rdsClient).flatMap {
-      case rdsInstance :: Nil => Attempt.Right(TunnelTargetWithHostName(target.localPort, rdsInstance.hostname, rdsInstance.port, target.remoteTags))
-      case Nil => Attempt.Left(Failure("Could not find target from tags", s"We could not find an RDS instance with the tags: ${target.remoteTags.mkString(", ")}", ArgumentsError))
+      case rdsInstance :: Nil =>
+        Attempt.Right(
+          TunnelTargetWithHostName(
+            target.localPort,
+            rdsInstance.hostname,
+            rdsInstance.port,
+            target.remoteTags
+          )
+        )
+      case Nil =>
+        Attempt.Left(
+          Failure(
+            "Could not find target from tags",
+            s"We could not find an RDS instance with the tags: ${target.remoteTags.mkString(", ")}",
+            ArgumentsError
+          )
+        )
       case tooManyInstances =>
-        Attempt.Left(Failure("More than one tunnel target resolved from tags", s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${target.remoteTags.mkString(", ")}", ArgumentsError))
+        Attempt.Left(
+          Failure(
+            "More than one tunnel target resolved from tags",
+            s"We expected to find a single target, but there was more than one tunnel target resolved from the tags: ${target.remoteTags.mkString(", ")}",
+            ArgumentsError
+          )
+        )
     }
   }
 
-  def executeOnInstances(instanceIds: List[InstanceId], username: String, cmd: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
+  def executeOnInstances(
+      instanceIds: List[InstanceId],
+      username: String,
+      cmd: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit
+      ec: ExecutionContext
+  ): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
     for {
       cmdId <- SSM.sendCommand(instanceIds, cmd, username, client)
       results <- SSM.getCmdOutputs(instanceIds, cmdId, client)
     } yield results
   }
 
-  def executeOnInstance(instanceId: InstanceId, username: String, script: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[Either[CommandStatus, CommandResult]] = {
+  def executeOnInstance(
+      instanceId: InstanceId,
+      username: String,
+      script: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit
+      ec: ExecutionContext
+  ): Attempt[Either[CommandStatus, CommandResult]] = {
     for {
       cmdId <- SSM.sendCommand(List(instanceId), script, username, client)
-      result <- SSM.getCmdOutput(instanceId, cmdId, client).map{ case (_, result) => result }
+      result <- SSM.getCmdOutput(instanceId, cmdId, client).map {
+        case (_, result) => result
+      }
     } yield result
   }
 
-  def executeOnInstanceAsync(instanceId: InstanceId, username: String, script: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
+  def executeOnInstanceAsync(
+      instanceId: InstanceId,
+      username: String,
+      script: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit ec: ExecutionContext): Attempt[String] = {
     for {
       cmdId <- SSM.sendCommand(List(instanceId), script, username, client)
     } yield cmdId
   }
 
-  def tagAsTainted(instanceId: InstanceId, username: String,ec2Client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] =
+  def tagAsTainted(
+      instanceId: InstanceId,
+      username: String,
+      ec2Client: AmazonEC2Async
+  )(implicit ec: ExecutionContext): Attempt[Unit] =
     EC2.tagInstance(instanceId, "taintedBy", username, ec2Client)
 
-  def getSSMConfig(ec2Client: AmazonEC2Async, stsClient: AWSSecurityTokenServiceAsync, executionTarget: ExecutionTarget)(implicit ec: ExecutionContext): Attempt[SSMConfig] = {
+  def getSSMConfig(
+      ec2Client: AmazonEC2Async,
+      stsClient: AWSSecurityTokenServiceAsync,
+      executionTarget: ExecutionTarget
+  )(implicit ec: ExecutionContext): Attempt[SSMConfig] = {
     for {
       instances <- IO.resolveInstances(executionTarget, ec2Client)
       name <- STS.getCallerIdentity(stsClient)

--- a/src/main/scala/com/gu/ssm/Logic.scala
+++ b/src/main/scala/com/gu/ssm/Logic.scala
@@ -20,19 +20,25 @@ object Logic {
   def generateScript(toExecute: Either[String, File]): String = {
     toExecute match {
       case Right(script) => Source.fromFile(script, "UTF-8").mkString
-      case Left(cmd) => cmd
+      case Left(cmd)     => cmd
     }
   }
 
   def extractSASTags(tags: Seq[String]): Either[String, List[String]] = {
-    if (tags.length > 3 || tags.isEmpty || tags.head.length == 0) Left("Please supply at least one and no more than 3 tags. " +
-      "If you specify less than 3 tags order assumed is app,stage,stack")
+    if (tags.length > 3 || tags.isEmpty || tags.head.length == 0)
+      Left(
+        "Please supply at least one and no more than 3 tags. " +
+          "If you specify less than 3 tags order assumed is app,stage,stack"
+      )
     else Right(tags.toList)
   }
 
-  val tunnelValidationErrorMsg = "Please specify a tunnel target in the format localPort:host:remotePort."
+  val tunnelValidationErrorMsg =
+    "Please specify a tunnel target in the format localPort:host:remotePort."
 
-  def extractTunnelConfig(tunnelStr: String): Either[String, TunnelTargetWithHostName] = {
+  def extractTunnelConfig(
+      tunnelStr: String
+  ): Either[String, TunnelTargetWithHostName] = {
     tunnelStr.split(":").toList match {
       case localPortStr :: targetStr :: remotePortStr :: Nil =>
         (localPortStr.toIntOption, targetStr, remotePortStr.toIntOption) match {
@@ -44,9 +50,12 @@ object Logic {
     }
   }
 
-  val rdsTunnelValidationErrorMsg = "Please specify a tunnel target in the format localPort:tags, where tags is a comma-separated list of tag values."
+  val rdsTunnelValidationErrorMsg =
+    "Please specify a tunnel target in the format localPort:tags, where tags is a comma-separated list of tag values."
 
-  def extractRDSTunnelConfig(tunnelStr: String): Either[String, TunnelTargetWithRDSTags] = {
+  def extractRDSTunnelConfig(
+      tunnelStr: String
+  ): Either[String, TunnelTargetWithRDSTags] = {
     tunnelStr.split(":").toList match {
       case localPortStr :: tagsStr :: Nil =>
         localPortStr.toIntOption match {
@@ -60,69 +69,127 @@ object Logic {
     }
   }
 
-  def checkInstancesList(config: SSMConfig): Either[FailedAttempt, Unit] = config.targets match {
-    case List() => Left(FailedAttempt(List(Failure("No instances found", "No instances found", ErrorCode))))
-    case _ => Right(())
-  }
+  def checkInstancesList(config: SSMConfig): Either[FailedAttempt, Unit] =
+    config.targets match {
+      case List() =>
+        Left(
+          FailedAttempt(
+            List(Failure("No instances found", "No instances found", ErrorCode))
+          )
+        )
+      case _ => Right(())
+    }
 
-  def getSSHInstance(instances: List[Instance], sism: SingleInstanceSelectionMode): Either[FailedAttempt, Instance] = {
+  def getSSHInstance(
+      instances: List[Instance],
+      sism: SingleInstanceSelectionMode
+  ): Either[FailedAttempt, Instance] = {
     instances.sortBy(_.launchInstant) match {
-      case Nil => Left(FailedAttempt(Failure(s"Unable to identify a single instance", s"Could not find any instance", UnhandledError)))
+      case Nil =>
+        Left(
+          FailedAttempt(
+            Failure(
+              s"Unable to identify a single instance",
+              s"Could not find any instance",
+              UnhandledError
+            )
+          )
+        )
       case instance :: Nil => Right(instance)
-      case _ :: _ :: _ if sism == SismUnspecified => Left(FailedAttempt(Failure(s"Unable to identify a single instance", s"Error choosing single instance, found ${instances.map(_.id.id).mkString(", ")}.  Use --oldest or --newest to select single instance", UnhandledError)))
-      case instances if sism == SismNewest => Right(instances.last) // we know that `instances` is not empty, otherwise first case would have applied, therefore calling `.last` is safe
+      case _ :: _ :: _ if sism == SismUnspecified =>
+        Left(
+          FailedAttempt(
+            Failure(
+              s"Unable to identify a single instance",
+              s"Error choosing single instance, found ${instances.map(_.id.id).mkString(", ")}.  Use --oldest or --newest to select single instance",
+              UnhandledError
+            )
+          )
+        )
+      case instances if sism == SismNewest =>
+        Right(
+          instances.last
+        ) // we know that `instances` is not empty, otherwise first case would have applied, therefore calling `.last` is safe
       case instance :: _ if sism == SismOldest => Right(instance)
     }
   }
 
-  def getClients(profile: Option[String], region: Region, useDefaultCredentialsProvider: Boolean): AWSClients = {
+  def getClients(
+      profile: Option[String],
+      region: Region,
+      useDefaultCredentialsProvider: Boolean
+  ): AWSClients = {
     val credentialsProvider = profile match {
-      case _ if useDefaultCredentialsProvider => DefaultAWSCredentialsProviderChain.getInstance()
+      case _ if useDefaultCredentialsProvider =>
+        DefaultAWSCredentialsProviderChain.getInstance()
       case Some(profile) => new ProfileCredentialsProvider(profile)
       // In this case it's set using the AWS_PROFILE environment variable
       case _ => new ProfileCredentialsProvider()
     }
 
-    val ssmClient: AWSSimpleSystemsManagementAsync = SSM.client(credentialsProvider, region)
-    val stsClient: AWSSecurityTokenServiceAsync = STS.client(credentialsProvider, region)
+    val ssmClient: AWSSimpleSystemsManagementAsync =
+      SSM.client(credentialsProvider, region)
+    val stsClient: AWSSecurityTokenServiceAsync =
+      STS.client(credentialsProvider, region)
     val ec2Client: AmazonEC2Async = EC2.client(credentialsProvider, region)
     val rdsClient: AmazonRDSAsync = RDS.client(credentialsProvider, region)
     AWSClients(ssmClient, stsClient, ec2Client, rdsClient)
   }
 
-  def computeIncorrectInstances(executionTarget: ExecutionTarget, instanceIds: List[InstanceId]): List[InstanceId] =
+  def computeIncorrectInstances(
+      executionTarget: ExecutionTarget,
+      instanceIds: List[InstanceId]
+  ): List[InstanceId] =
     executionTarget.instances.getOrElse(List()).filterNot(instanceIds.toSet)
 
-  def getAddress(instance: Instance, onlyUsePrivateIP: Boolean): Either[FailedAttempt, String] = {
+  def getAddress(
+      instance: Instance,
+      onlyUsePrivateIP: Boolean
+  ): Either[FailedAttempt, String] = {
     if (onlyUsePrivateIP) {
       Right(instance.privateIpAddress)
     } else {
       instance.publicIpAddressOpt match {
         case Some(ipAddress) => Right(ipAddress)
-        case None => Right(instance.privateIpAddress)
+        case None            => Right(instance.privateIpAddress)
       }
     }
   }
 
-  def getHostKeyEntry(ssmResult: Either[CommandStatus, CommandResult], preferredAlgs: List[String]): Either[FailedAttempt, String] = {
+  def getHostKeyEntry(
+      ssmResult: Either[CommandStatus, CommandResult],
+      preferredAlgs: List[String]
+  ): Either[FailedAttempt, String] = {
     ssmResult match {
       case Right(result) =>
         val resultLines = result.stdOut.linesIterator
-        val preferredKeys = resultLines.filter(hostKey => preferredAlgs.exists(hostKey.startsWith))
+        val preferredKeys = resultLines.filter(hostKey =>
+          preferredAlgs.exists(hostKey.startsWith)
+        )
         val preferenceOrderedKeys: Seq[String] = preferredKeys.toList.sortBy(
           hostKey => preferredAlgs.indexWhere(hostKey.startsWith)
         )
 
         preferenceOrderedKeys.headOption match {
           case Some(hostKey) => Right(hostKey)
-          case None => Left(Failure(
-            "host key with preferred algorithm not found",
-            s"The remote instance did not return a host key with any preferred algorithm (preferred: $preferredAlgs)",
-            NoHostKey,
-            s"The result lines returned from the host:\n${resultLines.mkString("\n")}"
-          ).attempt)
+          case None =>
+            Left(
+              Failure(
+                "host key with preferred algorithm not found",
+                s"The remote instance did not return a host key with any preferred algorithm (preferred: $preferredAlgs)",
+                NoHostKey,
+                s"The result lines returned from the host:\n${resultLines.mkString("\n")}"
+              ).attempt
+            )
         }
-      case Left(otherStatus) => Left(Failure("host keys not returned", s"The remote instance failed to return the host keys within the timeout window (status: $otherStatus)", AwsError).attempt)
+      case Left(otherStatus) =>
+        Left(
+          Failure(
+            "host keys not returned",
+            s"The remote instance failed to return the host keys within the timeout window (status: $otherStatus)",
+            AwsError
+          ).attempt
+        )
     }
   }
 

--- a/src/main/scala/com/gu/ssm/Main.scala
+++ b/src/main/scala/com/gu/ssm/Main.scala
@@ -12,26 +12,106 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val (result, verbose) = argParser.parse(args, Arguments.empty()) match {
-      case Some(Arguments(verbose, Some(executionTarget), toExecuteOpt, profile, region, Some(mode), Some(user), sism, _, _, onlyUsePrivateIP, rawOutput, bastionInstanceIdOpt, bastionPortNumberOpt, Some(bastionUser), targetInstancePortNumberOpt, useAgent, preferredAlgs, sourceFileOpt, targetFileOpt, tunnelThroughSystemsManager, useDefaultCredentialsProvider, tunnelTarget, rdsTunnelTarget)) =>
-        val awsClients = Logic.getClients(profile, region, useDefaultCredentialsProvider)
+      case Some(
+            Arguments(
+              verbose,
+              Some(executionTarget),
+              toExecuteOpt,
+              profile,
+              region,
+              Some(mode),
+              Some(user),
+              sism,
+              _,
+              _,
+              onlyUsePrivateIP,
+              rawOutput,
+              bastionInstanceIdOpt,
+              bastionPortNumberOpt,
+              Some(bastionUser),
+              targetInstancePortNumberOpt,
+              useAgent,
+              preferredAlgs,
+              sourceFileOpt,
+              targetFileOpt,
+              tunnelThroughSystemsManager,
+              useDefaultCredentialsProvider,
+              tunnelTarget,
+              rdsTunnelTarget
+            )
+          ) =>
+        val awsClients =
+          Logic.getClients(profile, region, useDefaultCredentialsProvider)
         val r = mode match {
           case SsmCmd =>
             toExecuteOpt match {
-              case Some(toExecute) => execute(awsClients, executionTarget, user, toExecute)
+              case Some(toExecute) =>
+                execute(awsClients, executionTarget, user, toExecute)
               case _ => fail
             }
-          case SsmSsh => bastionInstanceIdOpt match {
-            case None => setUpStandardSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, targetInstancePortNumberOpt, preferredAlgs, useAgent, profile, region, tunnelThroughSystemsManager, tunnelTarget.orElse(rdsTunnelTarget))
-            case Some(bastionInstance) => setUpBastionSSH(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, bastionInstance, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, preferredAlgs)
-          }
-          case SsmScp => (sourceFileOpt, targetFileOpt) match {
-            case (Some(sourceFile), Some(targetFile)) => setUpStandardScp(awsClients, executionTarget, user, sism, onlyUsePrivateIP, rawOutput, targetInstancePortNumberOpt, preferredAlgs, useAgent, sourceFile, targetFile, profile, region, tunnelThroughSystemsManager)
-            case _ => fail
-          }
+          case SsmSsh =>
+            bastionInstanceIdOpt match {
+              case None =>
+                setUpStandardSSH(
+                  awsClients,
+                  executionTarget,
+                  user,
+                  sism,
+                  onlyUsePrivateIP,
+                  rawOutput,
+                  targetInstancePortNumberOpt,
+                  preferredAlgs,
+                  useAgent,
+                  profile,
+                  region,
+                  tunnelThroughSystemsManager,
+                  tunnelTarget.orElse(rdsTunnelTarget)
+                )
+              case Some(bastionInstance) =>
+                setUpBastionSSH(
+                  awsClients,
+                  executionTarget,
+                  user,
+                  sism,
+                  onlyUsePrivateIP,
+                  rawOutput,
+                  bastionInstance,
+                  bastionPortNumberOpt,
+                  bastionUser,
+                  targetInstancePortNumberOpt,
+                  useAgent,
+                  preferredAlgs
+                )
+            }
+          case SsmScp =>
+            (sourceFileOpt, targetFileOpt) match {
+              case (Some(sourceFile), Some(targetFile)) =>
+                setUpStandardScp(
+                  awsClients,
+                  executionTarget,
+                  user,
+                  sism,
+                  onlyUsePrivateIP,
+                  rawOutput,
+                  targetInstancePortNumberOpt,
+                  preferredAlgs,
+                  useAgent,
+                  sourceFile,
+                  targetFile,
+                  profile,
+                  region,
+                  tunnelThroughSystemsManager
+                )
+              case _ => fail
+            }
         }
         r -> verbose
       case Some(_) => fail -> false
-      case None => ProgramResult(Nil, Some(ArgumentsError)) -> false // parsing cmd line args failed, help message will have been displayed
+      case None =>
+        ProgramResult(
+          Nil,
+          Some(ArgumentsError)
+        ) -> false // parsing cmd line args failed, help message will have been displayed
     }
 
     val ui = new UI(verbose)
@@ -40,128 +120,294 @@ object Main {
   }
 
   private def fail: ProgramResult = {
-    ProgramResult(Seq(Err("Impossible application state! This should be enforced by the CLI parser.  Did not receive valid instructions")), Some(UnhandledError))
+    ProgramResult(
+      Seq(
+        Err(
+          "Impossible application state! This should be enforced by the CLI parser.  Did not receive valid instructions"
+        )
+      ),
+      Some(UnhandledError)
+    )
   }
 
   private def setUpStandardSSH(
-    awsClients: AWSClients,
-    executionTarget: ExecutionTarget,
-    user: String,
-    sism: SingleInstanceSelectionMode,
-    onlyUsePrivateIP: Boolean,
-    rawOutput: Boolean,
-    targetInstancePortNumberOpt: Option[Int],
-    preferredAlgs: List[String],
-    useAgent: Option[Boolean],
-    profile: Option[String],
-    region: Region,
-    tunnelThroughSystemsManager: Boolean,
-    tunnelTarget: Option[TunnelTarget]): ProgramResult = {
+      awsClients: AWSClients,
+      executionTarget: ExecutionTarget,
+      user: String,
+      sism: SingleInstanceSelectionMode,
+      onlyUsePrivateIP: Boolean,
+      rawOutput: Boolean,
+      targetInstancePortNumberOpt: Option[Int],
+      preferredAlgs: List[String],
+      useAgent: Option[Boolean],
+      profile: Option[String],
+      region: Region,
+      tunnelThroughSystemsManager: Boolean,
+      tunnelTarget: Option[TunnelTarget]
+  ): ProgramResult = {
     val fProgramResult = for {
-      config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
+      config <- IO.getSSMConfig(
+        awsClients.ec2Client,
+        awsClients.stsClient,
+        executionTarget
+      )
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (privateKeyFile, publicKey) = sshArtifacts
-      addPublicKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
+      addPublicKeyCommand = SSH.addTaintedCommand(config.name) + SSH
+        .addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
       resolvedTunnelTarget <- Attempt.sequence(tunnelTarget.toList.map {
-        case t: TunnelTargetWithRDSTags => IO.resolveRDSTunnelTarget(t, awsClients.rdsClient)
+        case t: TunnelTargetWithRDSTags =>
+          IO.resolveRDSTunnelTarget(t, awsClients.rdsClient)
         case t: TunnelTargetWithHostName => Attempt.Right(t)
       })
       removePublicKeyCommand = SSH.removePublicKeyCommand(user, publicKey)
       instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, sism))
       _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
-      result <- IO.executeOnInstance(instance.id, config.name, addPublicKeyCommand, awsClients.ssmClient)
-      _ <- IO.executeOnInstanceAsync(instance.id, config.name, removePublicKeyCommand, awsClients.ssmClient)
-      hostKey <- Attempt.fromEither(Logic.getHostKeyEntry(result, preferredAlgs))
-      address <- Attempt.fromEither(Logic.getAddress(instance, onlyUsePrivateIP))
+      result <- IO.executeOnInstance(
+        instance.id,
+        config.name,
+        addPublicKeyCommand,
+        awsClients.ssmClient
+      )
+      _ <- IO.executeOnInstanceAsync(
+        instance.id,
+        config.name,
+        removePublicKeyCommand,
+        awsClients.ssmClient
+      )
+      hostKey <- Attempt.fromEither(
+        Logic.getHostKeyEntry(result, preferredAlgs)
+      )
+      address <- Attempt.fromEither(
+        Logic.getAddress(instance, onlyUsePrivateIP)
+      )
       hostKeyFile <- SSH.writeHostKey((address, hostKey))
     } yield {
-      SSH.sshCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, Some(hostKeyFile), useAgent, profile, region, tunnelThroughSystemsManager, resolvedTunnelTarget.headOption)
+      SSH.sshCmdStandard(rawOutput)(
+        privateKeyFile,
+        instance,
+        user,
+        address,
+        targetInstancePortNumberOpt,
+        Some(hostKeyFile),
+        useAgent,
+        profile,
+        region,
+        tunnelThroughSystemsManager,
+        resolvedTunnelTarget.headOption
+      )
     }
     val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
-    ProgramResult.convertErrorToResult(programResult.map(UI.sshOutput(rawOutput)))
+    ProgramResult.convertErrorToResult(
+      programResult.map(UI.sshOutput(rawOutput))
+    )
   }
 
   private def setUpBastionSSH(
-    awsClients: AWSClients,
-    executionTarget: ExecutionTarget,
-    user: String,
-    sism: SingleInstanceSelectionMode,
-    onlyUsePrivateIP: Boolean,
-    rawOutput: Boolean,
-    bastionInstance: ExecutionTarget,
-    bastionPortNumberOpt: Option[Int],
-    bastionUser: String,
-    targetInstancePortNumberOpt: Option[Int],
-    useAgent: Option[Boolean],
-    preferredAlgs: List[String]): ProgramResult = {
+      awsClients: AWSClients,
+      executionTarget: ExecutionTarget,
+      user: String,
+      sism: SingleInstanceSelectionMode,
+      onlyUsePrivateIP: Boolean,
+      rawOutput: Boolean,
+      bastionInstance: ExecutionTarget,
+      bastionPortNumberOpt: Option[Int],
+      bastionUser: String,
+      targetInstancePortNumberOpt: Option[Int],
+      useAgent: Option[Boolean],
+      preferredAlgs: List[String]
+  ): ProgramResult = {
     val fProgramResult = for {
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (privateKeyFile, publicKey) = sshArtifacts
-      bastionConfig <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, bastionInstance)
-      bastionInstance <- Attempt.fromEither(Logic.getSSHInstance(bastionConfig.targets, sism))
-      bastionAddPublicKeyCommand = SSH.addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
-      bastionRemovePublicKeyCommand = SSH.removePublicKeyCommand(user, publicKey)
-      bastionAddress <- Attempt.fromEither(Logic.getAddress(bastionInstance, onlyUsePrivateIP))
-      targetConfig <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
-      targetInstance <- Attempt.fromEither(Logic.getSSHInstance(targetConfig.targets, sism))
-      targetAddress <- Attempt.fromEither(Logic.getAddress(targetInstance, true))
-      targetAddPublicKeyCommand = SSH.addTaintedCommand(targetConfig.name) + SSH.addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
+      bastionConfig <- IO.getSSMConfig(
+        awsClients.ec2Client,
+        awsClients.stsClient,
+        bastionInstance
+      )
+      bastionInstance <- Attempt.fromEither(
+        Logic.getSSHInstance(bastionConfig.targets, sism)
+      )
+      bastionAddPublicKeyCommand = SSH.addPublicKeyCommand(
+        user,
+        publicKey
+      ) + SSH.outputHostKeysCommand()
+      bastionRemovePublicKeyCommand = SSH.removePublicKeyCommand(
+        user,
+        publicKey
+      )
+      bastionAddress <- Attempt.fromEither(
+        Logic.getAddress(bastionInstance, onlyUsePrivateIP)
+      )
+      targetConfig <- IO.getSSMConfig(
+        awsClients.ec2Client,
+        awsClients.stsClient,
+        executionTarget
+      )
+      targetInstance <- Attempt.fromEither(
+        Logic.getSSHInstance(targetConfig.targets, sism)
+      )
+      targetAddress <- Attempt.fromEither(
+        Logic.getAddress(targetInstance, true)
+      )
+      targetAddPublicKeyCommand = SSH.addTaintedCommand(targetConfig.name) + SSH
+        .addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
       targetRemovePublicKeyCommand = SSH.removePublicKeyCommand(user, publicKey)
-      bastionResult <- IO.executeOnInstance(bastionInstance.id, bastionConfig.name, bastionAddPublicKeyCommand, awsClients.ssmClient)
-      _ <- IO.executeOnInstanceAsync(bastionInstance.id, bastionConfig.name, bastionRemovePublicKeyCommand, awsClients.ssmClient)
-      _ <- IO.tagAsTainted(targetInstance.id, targetConfig.name, awsClients.ec2Client)
-      targetResult <- IO.executeOnInstance(targetInstance.id, targetConfig.name, targetAddPublicKeyCommand, awsClients.ssmClient)
-      _ <- IO.executeOnInstanceAsync(targetInstance.id, targetConfig.name, targetRemovePublicKeyCommand, awsClients.ssmClient)
-      bastionHostKey <- Attempt.fromEither(Logic.getHostKeyEntry(bastionResult, preferredAlgs))
-      targetHostKey <- Attempt.fromEither(Logic.getHostKeyEntry(targetResult, preferredAlgs))
-      hostKeyFile <- SSH.writeHostKey((bastionAddress, bastionHostKey), (targetAddress, targetHostKey))
-    } yield SSH.sshCmdBastion(rawOutput)(privateKeyFile, bastionInstance, targetInstance, user, bastionAddress, targetAddress, bastionPortNumberOpt, bastionUser, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile))
+      bastionResult <- IO.executeOnInstance(
+        bastionInstance.id,
+        bastionConfig.name,
+        bastionAddPublicKeyCommand,
+        awsClients.ssmClient
+      )
+      _ <- IO.executeOnInstanceAsync(
+        bastionInstance.id,
+        bastionConfig.name,
+        bastionRemovePublicKeyCommand,
+        awsClients.ssmClient
+      )
+      _ <- IO.tagAsTainted(
+        targetInstance.id,
+        targetConfig.name,
+        awsClients.ec2Client
+      )
+      targetResult <- IO.executeOnInstance(
+        targetInstance.id,
+        targetConfig.name,
+        targetAddPublicKeyCommand,
+        awsClients.ssmClient
+      )
+      _ <- IO.executeOnInstanceAsync(
+        targetInstance.id,
+        targetConfig.name,
+        targetRemovePublicKeyCommand,
+        awsClients.ssmClient
+      )
+      bastionHostKey <- Attempt.fromEither(
+        Logic.getHostKeyEntry(bastionResult, preferredAlgs)
+      )
+      targetHostKey <- Attempt.fromEither(
+        Logic.getHostKeyEntry(targetResult, preferredAlgs)
+      )
+      hostKeyFile <- SSH.writeHostKey(
+        (bastionAddress, bastionHostKey),
+        (targetAddress, targetHostKey)
+      )
+    } yield SSH.sshCmdBastion(rawOutput)(
+      privateKeyFile,
+      bastionInstance,
+      targetInstance,
+      user,
+      bastionAddress,
+      targetAddress,
+      bastionPortNumberOpt,
+      bastionUser,
+      targetInstancePortNumberOpt,
+      useAgent,
+      Some(hostKeyFile)
+    )
     val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
-    ProgramResult.convertErrorToResult(programResult.map(UI.sshOutput(rawOutput)))
+    ProgramResult.convertErrorToResult(
+      programResult.map(UI.sshOutput(rawOutput))
+    )
   }
 
   private def setUpStandardScp(
-                                awsClients: AWSClients,
-                                executionTarget: ExecutionTarget,
-                                user: String,
-                                sism: SingleInstanceSelectionMode,
-                                onlyUsePrivateIP: Boolean,
-                                rawOutput: Boolean,
-                                targetInstancePortNumberOpt: Option[Int],
-                                preferredAlgs: List[String],
-                                useAgent: Option[Boolean],
-                                sourceFile: String,
-                                targetFile: String,
-                                profile: Option[String],
-                                region: Region,
-                                tunnelThroughSystemsManager: Boolean): ProgramResult = {
+      awsClients: AWSClients,
+      executionTarget: ExecutionTarget,
+      user: String,
+      sism: SingleInstanceSelectionMode,
+      onlyUsePrivateIP: Boolean,
+      rawOutput: Boolean,
+      targetInstancePortNumberOpt: Option[Int],
+      preferredAlgs: List[String],
+      useAgent: Option[Boolean],
+      sourceFile: String,
+      targetFile: String,
+      profile: Option[String],
+      region: Region,
+      tunnelThroughSystemsManager: Boolean
+  ): ProgramResult = {
     val fProgramResult = for {
-      config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
+      config <- IO.getSSMConfig(
+        awsClients.ec2Client,
+        awsClients.stsClient,
+        executionTarget
+      )
       sshArtifacts <- Attempt.fromEither(SSH.createKey())
       (privateKeyFile, publicKey) = sshArtifacts
-      addPublicKeyCommand = SSH.addTaintedCommand(config.name) + SSH.addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
+      addPublicKeyCommand = SSH.addTaintedCommand(config.name) + SSH
+        .addPublicKeyCommand(user, publicKey) + SSH.outputHostKeysCommand()
       removePublicKeyCommand = SSH.removePublicKeyCommand(user, publicKey)
       instance <- Attempt.fromEither(Logic.getSSHInstance(config.targets, sism))
       _ <- IO.tagAsTainted(instance.id, config.name, awsClients.ec2Client)
-      result <- IO.executeOnInstance(instance.id, config.name, addPublicKeyCommand, awsClients.ssmClient)
-      _ <- IO.executeOnInstanceAsync(instance.id, config.name, removePublicKeyCommand, awsClients.ssmClient)
-      hostKey <- Attempt.fromEither(Logic.getHostKeyEntry(result, preferredAlgs))
-      address <- Attempt.fromEither(Logic.getAddress(instance, onlyUsePrivateIP))
+      result <- IO.executeOnInstance(
+        instance.id,
+        config.name,
+        addPublicKeyCommand,
+        awsClients.ssmClient
+      )
+      _ <- IO.executeOnInstanceAsync(
+        instance.id,
+        config.name,
+        removePublicKeyCommand,
+        awsClients.ssmClient
+      )
+      hostKey <- Attempt.fromEither(
+        Logic.getHostKeyEntry(result, preferredAlgs)
+      )
+      address <- Attempt.fromEither(
+        Logic.getAddress(instance, onlyUsePrivateIP)
+      )
       hostKeyFile <- SSH.writeHostKey((address, hostKey))
     } yield {
-      SSH.scpCmdStandard(rawOutput)(privateKeyFile, instance, user, address, targetInstancePortNumberOpt, useAgent, Some(hostKeyFile), sourceFile, targetFile, profile, region, tunnelThroughSystemsManager)
+      SSH.scpCmdStandard(rawOutput)(
+        privateKeyFile,
+        instance,
+        user,
+        address,
+        targetInstancePortNumberOpt,
+        useAgent,
+        Some(hostKeyFile),
+        sourceFile,
+        targetFile,
+        profile,
+        region,
+        tunnelThroughSystemsManager
+      )
     }
     val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
-    ProgramResult.convertErrorToResult(programResult.map(UI.sshOutput(rawOutput)))
+    ProgramResult.convertErrorToResult(
+      programResult.map(UI.sshOutput(rawOutput))
+    )
   }
 
-  private def execute(awsClients: AWSClients, executionTarget: ExecutionTarget, user: String, toExecute: String): ProgramResult = {
+  private def execute(
+      awsClients: AWSClients,
+      executionTarget: ExecutionTarget,
+      user: String,
+      toExecute: String
+  ): ProgramResult = {
     val fProgramResult = for {
-      config <- IO.getSSMConfig(awsClients.ec2Client, awsClients.stsClient, executionTarget)
+      config <- IO.getSSMConfig(
+        awsClients.ec2Client,
+        awsClients.stsClient,
+        executionTarget
+      )
       _ <- Attempt.fromEither(Logic.checkInstancesList(config))
-      results <- IO.executeOnInstances(config.targets.map(i => i.id), user, toExecute, awsClients.ssmClient)
-      incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(executionTarget, results.map(_._1))
-    } yield ResultsWithInstancesNotFound(results, incorrectInstancesFromInstancesTag)
+      results <- IO.executeOnInstances(
+        config.targets.map(i => i.id),
+        user,
+        toExecute,
+        awsClients.ssmClient
+      )
+      incorrectInstancesFromInstancesTag = Logic.computeIncorrectInstances(
+        executionTarget,
+        results.map(_._1)
+      )
+    } yield ResultsWithInstancesNotFound(
+      results,
+      incorrectInstancesFromInstancesTag
+    )
 
     val programResult = Await.result(fProgramResult.asFuture, Duration.Inf)
     ProgramResult.convertErrorToResult(programResult.map(UI.output))

--- a/src/main/scala/com/gu/ssm/SSH.scala
+++ b/src/main/scala/com/gu/ssm/SSH.scala
@@ -21,20 +21,49 @@ object SSH {
     val keyProvider = "BC"
 
     try {
-      val privateKeyFile = File.createTempFile(prefix, suffix, new File(System.getProperty("java.io.tmpdir")))
+      val privateKeyFile = File.createTempFile(
+        prefix,
+        suffix,
+        new File(System.getProperty("java.io.tmpdir"))
+      )
       FilePermissions(privateKeyFile, "0600")
-      val publicKey = KeyMaker.makeKey(privateKeyFile, keyAlgorithm, keyProvider)
+      val publicKey =
+        KeyMaker.makeKey(privateKeyFile, keyAlgorithm, keyProvider)
       Right((privateKeyFile, publicKey))
     } catch {
-      case e:IOException => Left(FailedAttempt(
-        Failure(s"Unable to create private key file", "Error creating key on disk", UnhandledError, e)
-      ))
-      case e:NoSuchAlgorithmException => Left(FailedAttempt(
-        Failure(s"Unable to create key pair with algorithm $keyAlgorithm", s"Error creating key with algorithm $keyAlgorithm", UnhandledError, e)
-      ))
-      case e:NoSuchProviderException => Left(FailedAttempt(
-        Failure(s"Unable to create key pair with provider $keyProvider", s"Error creating key with provider $keyProvider", UnhandledError, e)
-      ))
+      case e: IOException =>
+        Left(
+          FailedAttempt(
+            Failure(
+              s"Unable to create private key file",
+              "Error creating key on disk",
+              UnhandledError,
+              e
+            )
+          )
+        )
+      case e: NoSuchAlgorithmException =>
+        Left(
+          FailedAttempt(
+            Failure(
+              s"Unable to create key pair with algorithm $keyAlgorithm",
+              s"Error creating key with algorithm $keyAlgorithm",
+              UnhandledError,
+              e
+            )
+          )
+        )
+      case e: NoSuchProviderException =>
+        Left(
+          FailedAttempt(
+            Failure(
+              s"Unable to create key pair with provider $keyProvider",
+              s"Error creating key with provider $keyProvider",
+              UnhandledError,
+              e
+            )
+          )
+        )
     }
   }
 
@@ -55,9 +84,15 @@ object SSH {
       }
       Attempt.Right(hostKeyFile)
     } catch {
-      case e:IOException => Attempt.Left(
-        Failure(s"Unable to create host key file", "Error creating host key on disk", UnhandledError, e)
-      )
+      case e: IOException =>
+        Attempt.Left(
+          Failure(
+            s"Unable to create host key file",
+            "Error creating host key on disk",
+            UnhandledError,
+            e
+          )
+        )
     }
   }
 
@@ -66,7 +101,9 @@ object SSH {
        | /usr/bin/test -d /etc/update-motd.d/ &&
        | ( /usr/bin/test -f /etc/update-motd.d/99-tainted || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
        |   /bin/echo -e 'echo -e "\\033[0;31mThis instance should be considered tainted.\\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
-       |   /bin/echo -e 'echo -e "\\033[0;31mIt was accessed by $name at ${Calendar.getInstance().getTime}\\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
+       |   /bin/echo -e 'echo -e "\\033[0;31mIt was accessed by $name at ${Calendar
+        .getInstance()
+        .getTime}\\033[0;39m"' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;
        |   /usr/bin/sudo /bin/chmod 0755 /etc/update-motd.d/99-tainted;
        |   /usr/bin/sudo /bin/run-parts /etc/update-motd.d/ | /usr/bin/sudo /usr/bin/tee /run/motd.dynamic >> /dev/null;
        | ) """.stripMargin
@@ -83,7 +120,10 @@ object SSH {
   def removePublicKeyCommand(user: String, publicKey: String): String =
     s"""
       | /bin/sleep $sshCredentialsLifetimeSeconds;
-      | /bin/sed -i '/${publicKey.replaceAll("/", "\\\\/")}/d' /home/$user/.ssh/authorized_keys;
+      | /bin/sed -i '/${publicKey.replaceAll(
+        "/",
+        "\\\\/"
+      )}/d' /home/$user/.ssh/authorized_keys;
       |""".stripMargin
 
   def outputHostKeysCommand(): String =
@@ -91,61 +131,115 @@ object SSH {
        | for hostkey in $(sshd -T 2> /dev/null |grep "^hostkey " | cut -d ' ' -f 2); do cat $hostkey.pub; done
      """.stripMargin
 
-  def sshCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], hostsFile: Option[File], useAgent: Option[Boolean], profile: Option[String], region: Region, tunnelThroughSystemsManager: Boolean, tunnelTarget: Option[TunnelTargetWithHostName]): (InstanceId, Seq[Output]) = {
+  def sshCmdStandard(rawOutput: Boolean)(
+      privateKeyFile: File,
+      instance: Instance,
+      user: String,
+      ipAddress: String,
+      targetInstancePortNumberOpt: Option[Int],
+      hostsFile: Option[File],
+      useAgent: Option[Boolean],
+      profile: Option[String],
+      region: Region,
+      tunnelThroughSystemsManager: Boolean,
+      tunnelTarget: Option[TunnelTargetWithHostName]
+  ): (InstanceId, Seq[Output]) = {
     val targetPortSpecifications = targetInstancePortNumberOpt match {
       case Some(portNumber) => s" -p ${portNumber}"
-      case _ => ""
+      case _                => ""
     }
-    val theTTOptions = if(rawOutput) { " -t -t" }else{ "" }
+    val theTTOptions = if (rawOutput) { " -t -t" }
+    else { "" }
     val useAgentFragment = useAgent match {
-      case None => ""
-      case Some(decision) => if(decision) " -A" else " -a"
+      case None           => ""
+      case Some(decision) => if (decision) " -A" else " -a"
     }
-    val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
-    val proxyFragment = if(tunnelThroughSystemsManager) { s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile.map("--profile " + _).getOrElse("")}\\""""" } else { "" }
+    val hostsFileString = hostsFile
+      .map(file =>
+        s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes""""
+      )
+      .getOrElse("")
+    val proxyFragment = if (tunnelThroughSystemsManager) {
+      s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile
+          .map("--profile " + _)
+          .getOrElse("")}\\"""""
+    } else { "" }
 
-    val (tunnelString, tunnelMeta) = tunnelTarget.map(t => (
-      s"-L ${t.localPort}:${t.remoteHostName}:${t.remotePort} -N -f",
-      Seq(
-        Metadata(s"# If the command succeeded, a tunnel has been established."),
-        Metadata(s"# Local port: ${t.localPort}"),
-        Metadata(s"# Remote address: ${t.remoteHostName}:${t.remotePort}")
-      ) ++ t.remoteTags.map(_.toLowerCase).find(_.contains("prod")).map { _ =>
-        Metadata(s"# The tags indicate that this is a PRODUCTION resource. Please take care! Perhaps bring a pair?")
-      }
-    )).getOrElse(("", Seq.empty))
+    val (tunnelString, tunnelMeta) = tunnelTarget
+      .map(t =>
+        (
+          s"-L ${t.localPort}:${t.remoteHostName}:${t.remotePort} -N -f",
+          Seq(
+            Metadata(
+              s"# If the command succeeded, a tunnel has been established."
+            ),
+            Metadata(s"# Local port: ${t.localPort}"),
+            Metadata(s"# Remote address: ${t.remoteHostName}:${t.remotePort}")
+          ) ++ t.remoteTags.map(_.toLowerCase).find(_.contains("prod")).map {
+            _ =>
+              Metadata(
+                s"# The tags indicate that this is a PRODUCTION resource. Please take care! Perhaps bring a pair?"
+              )
+          }
+        )
+      )
+      .getOrElse(("", Seq.empty))
 
-    val connectionString = s"""ssh -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$targetPortSpecifications$proxyFragment -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress $tunnelString""".trim()
+    val connectionString =
+      s"""ssh -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$targetPortSpecifications$proxyFragment -i ${privateKeyFile.getCanonicalFile.toString}${theTTOptions} $user@$ipAddress $tunnelString"""
+        .trim()
 
     val cmd = if (rawOutput) {
       Seq(Out(s"$connectionString", newline = false)) ++ tunnelMeta.toList
     } else {
       Seq(
-        Metadata(s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"),
+        Metadata(
+          s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"
+        ),
         Out(s"$connectionString;")
       )
     }
     (instance.id, cmd)
   }
 
-  def sshCmdBastion(rawOutput: Boolean)(privateKeyFile: File, bastionInstance: Instance, targetInstance: Instance, targetInstanceUser: String, bastionIpAddress: String, targetIpAddress: String, bastionPortNumberOpt: Option[Int], bastionUser: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File]): (InstanceId, Seq[Output]) = {
+  def sshCmdBastion(rawOutput: Boolean)(
+      privateKeyFile: File,
+      bastionInstance: Instance,
+      targetInstance: Instance,
+      targetInstanceUser: String,
+      bastionIpAddress: String,
+      targetIpAddress: String,
+      bastionPortNumberOpt: Option[Int],
+      bastionUser: String,
+      targetInstancePortNumberOpt: Option[Int],
+      useAgent: Option[Boolean],
+      hostsFile: Option[File]
+  ): (InstanceId, Seq[Output]) = {
     val bastionPort = bastionPortNumberOpt.getOrElse(22)
     val targetPort = targetInstancePortNumberOpt.getOrElse(22)
-    val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
+    val hostsFileString = hostsFile
+      .map(file =>
+        s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes""""
+      )
+      .getOrElse("")
     val identityFragment = s"-i ${privateKeyFile.getCanonicalFile.toString}"
-    val proxyFragment = s"""-o 'ProxyCommand ssh -o "IdentitiesOnly yes" $identityFragment$hostsFileString -p $bastionPort $bastionUser@$bastionIpAddress nc $targetIpAddress $targetPort'"""
-    val stringFragmentTTOptions = if(rawOutput) { " -t -t" } else { "" }
+    val proxyFragment =
+      s"""-o 'ProxyCommand ssh -o "IdentitiesOnly yes" $identityFragment$hostsFileString -p $bastionPort $bastionUser@$bastionIpAddress nc $targetIpAddress $targetPort'"""
+    val stringFragmentTTOptions = if (rawOutput) { " -t -t" }
+    else { "" }
     val useAgentFragment = useAgent match {
-      case None => ""
-      case Some(decision) => if(decision) " -A" else " -a"
+      case None           => ""
+      case Some(decision) => if (decision) " -A" else " -a"
     }
     val connectionString =
       s"""ssh$useAgentFragment -o "IdentitiesOnly yes" $identityFragment$hostsFileString $proxyFragment$stringFragmentTTOptions $targetInstanceUser@$targetIpAddress"""
-    val cmd = if(rawOutput) {
+    val cmd = if (rawOutput) {
       Seq(Out(s"$connectionString", newline = false))
-    }else{
+    } else {
       Seq(
-        Metadata(s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"),
+        Metadata(
+          s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"
+        ),
         Out(s"$connectionString;")
       )
     }
@@ -155,46 +249,81 @@ object SSH {
   // The first file goes to the second file
   // The remote file is indicated by a colon
 
-  def scpCmdStandard(rawOutput: Boolean)(privateKeyFile: File, instance: Instance, user: String, ipAddress: String, targetInstancePortNumberOpt: Option[Int], useAgent: Option[Boolean], hostsFile: Option[File], sourceFile: String, targetFile: String, profile: Option[String], region: Region, tunnelThroughSystemsManager: Boolean): (InstanceId, Seq[Output]) = {
+  def scpCmdStandard(rawOutput: Boolean)(
+      privateKeyFile: File,
+      instance: Instance,
+      user: String,
+      ipAddress: String,
+      targetInstancePortNumberOpt: Option[Int],
+      useAgent: Option[Boolean],
+      hostsFile: Option[File],
+      sourceFile: String,
+      targetFile: String,
+      profile: Option[String],
+      region: Region,
+      tunnelThroughSystemsManager: Boolean
+  ): (InstanceId, Seq[Output]) = {
 
     def isRemote(filepath: String): Boolean = {
       filepath.startsWith(":")
     }
 
-    def exactlyOneArgumentIsRemote(filepath1: String, filepath2: String): Boolean = {
+    def exactlyOneArgumentIsRemote(
+        filepath1: String,
+        filepath2: String
+    ): Boolean = {
       List(filepath1, filepath2).map(isRemote).count(_ == true) == 1
     }
 
     val targetPortSpecifications = targetInstancePortNumberOpt match {
       case Some(portNumber) => s" -p ${portNumber}"
-      case _ => ""
+      case _                => ""
     }
-    val hostsFileString = hostsFile.map(file => s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes"""").getOrElse("")
-    val proxyFragment = if(tunnelThroughSystemsManager) { s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile.map("--profile " + _).getOrElse("")}\\""""" } else { "" }
+    val hostsFileString = hostsFile
+      .map(file =>
+        s""" -o "UserKnownHostsFile $file" -o "StrictHostKeyChecking yes""""
+      )
+      .getOrElse("")
+    val proxyFragment = if (tunnelThroughSystemsManager) {
+      s""" -o "ProxyCommand sh -c \\"aws ssm start-session --target ${instance.id.id} --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region $region ${profile
+          .map("--profile " + _)
+          .getOrElse("")}\\"""""
+    } else { "" }
     val useAgentFragment = useAgent match {
-      case None => ""
-      case Some(decision) => if(decision) " -A" else " -a"
+      case None           => ""
+      case Some(decision) => if (decision) " -A" else " -a"
     }
     // We are using colon to designate the remote file.
     // There should be only one.
     if (exactlyOneArgumentIsRemote(sourceFile, targetFile)) {
       val connectionString =
         if (isRemote(sourceFile)) {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$proxyFragment${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} $user@$ipAddress:${sourceFile.stripPrefix(":")} ${targetFile}"""
-        }else {
-          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$proxyFragment${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} ${sourceFile} $user@$ipAddress:${targetFile.stripPrefix(":")}"""
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$proxyFragment${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} $user@$ipAddress:${sourceFile
+              .stripPrefix(":")} ${targetFile}"""
+        } else {
+          s"""scp -o "IdentitiesOnly yes"$useAgentFragment$hostsFileString$proxyFragment${targetPortSpecifications} -i ${privateKeyFile.getCanonicalFile.toString} ${sourceFile} $user@$ipAddress:${targetFile
+              .stripPrefix(":")}"""
         }
-      val cmd = if(rawOutput) {
+      val cmd = if (rawOutput) {
         Seq(Out(s"$connectionString", newline = false))
-      }else{
+      } else {
         Seq(
-          Metadata(s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"),
+          Metadata(
+            s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"
+          ),
           Out(s"$connectionString;")
         )
       }
       (instance.id, cmd)
-    }else{
-      (instance.id, Seq(Err("Incorrect remote server specifications, only one file should carry the starting colon")))
+    } else {
+      (
+        instance.id,
+        Seq(
+          Err(
+            "Incorrect remote server specifications, only one file should carry the starting colon"
+          )
+        )
+      )
     }
 
   }

--- a/src/main/scala/com/gu/ssm/UI.scala
+++ b/src/main/scala/com/gu/ssm/UI.scala
@@ -105,7 +105,7 @@ object UI {
 class UI(verbose: Boolean) {
   import UI._
 
-  def printAll(output: Seq[Output]): Unit = print(output: _*)
+  def printAll(output: Seq[Output]): Unit = print(output*)
 
   def print(output: Output*): Unit = {
     output.foreach {

--- a/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
+++ b/src/main/scala/com/gu/ssm/aws/AwsAsyncHandler.scala
@@ -2,45 +2,89 @@ package com.gu.ssm.aws
 
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
-import com.gu.ssm.utils.attempt.{Attempt, AwsError, AwsPermissionsError, Failure}
+import com.gu.ssm.utils.attempt.{
+  Attempt,
+  AwsError,
+  AwsPermissionsError,
+  Failure
+}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-
 object AwsAsyncHandler {
   private val ServiceName = ".*Service: ([^;]+);.*".r
-  def awsToScala[R <: AmazonWebServiceRequest, T](sdkMethod: ( (R, AsyncHandler[R, T]) => java.util.concurrent.Future[T])): (R => Future[T]) = { req =>
+  def awsToScala[R <: AmazonWebServiceRequest, T](
+      sdkMethod: ((R, AsyncHandler[R, T]) => java.util.concurrent.Future[T])
+  ): R => Future[T] = { req =>
     val p = Promise[T]()
     sdkMethod(req, new AwsAsyncPromiseHandler(p))
     p.future
   }
 
-  /**
-    * Handles expected AWS errors in a nice way
+  /** Handles expected AWS errors in a nice way
     */
-  def handleAWSErrs[T](f: Future[T])(implicit ec: ExecutionContext): Attempt[T] = {
+  def handleAWSErrs[T](
+      f: Future[T]
+  )(implicit ec: ExecutionContext): Attempt[T] = {
     Attempt.fromFuture(f) { case e =>
       val serviceNameOpt = e.getMessage match {
         case ServiceName(serviceName) => Some(serviceName)
-        case _ => None
+        case _                        => None
       }
       if (e.getMessage.contains("Request has expired")) {
-        Failure("expired AWS credentials", "Failed to request data from AWS, the temporary credentials have expired", AwsPermissionsError, e).attempt
-      } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
-        Failure("No AWS credentials found", "No AWS credentials found. Did you mean to set --profile?", AwsPermissionsError, e).attempt
+        Failure(
+          "expired AWS credentials",
+          "Failed to request data from AWS, the temporary credentials have expired",
+          AwsPermissionsError,
+          e
+        ).attempt
+      } else if (
+        e.getMessage.contains(
+          "Unable to load AWS credentials from any provider in the chain"
+        )
+      ) {
+        Failure(
+          "No AWS credentials found",
+          "No AWS credentials found. Did you mean to set --profile?",
+          AwsPermissionsError,
+          e
+        ).attempt
       } else if (e.getMessage.contains("No AWS profile named")) {
-        Failure("Invalid AWS profile name (does not exist)", "The specified AWS profile does not exist", AwsPermissionsError, e).attempt
+        Failure(
+          "Invalid AWS profile name (does not exist)",
+          "The specified AWS profile does not exist",
+          AwsPermissionsError,
+          e
+        ).attempt
       } else if (e.getMessage.contains("is not authorized to perform")) {
-        val message = serviceNameOpt.fold("You do not have sufficient AWS privileges")(serviceName => s"You do not have sufficient privileges to perform actions on $serviceName")
-        Failure("insufficient permissions", message, AwsPermissionsError, e).attempt
+        val message = serviceNameOpt.fold(
+          "You do not have sufficient AWS privileges"
+        )(serviceName =>
+          s"You do not have sufficient privileges to perform actions on $serviceName"
+        )
+        Failure(
+          "insufficient permissions",
+          message,
+          AwsPermissionsError,
+          e
+        ).attempt
       } else if (e.getMessage.contains("InvalidInstanceId")) {
-        Failure("InvalidInstanceId from AWS", "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)", AwsError, e).attempt
+        Failure(
+          "InvalidInstanceId from AWS",
+          "The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)",
+          AwsError,
+          e
+        ).attempt
       } else {
-        val details = serviceNameOpt.fold(s"AWS unknown error, unknown service (check logs for stacktrace). $e") { serviceName =>
+        val details = serviceNameOpt.fold(
+          s"AWS unknown error, unknown service (check logs for stacktrace). $e"
+        ) { serviceName =>
           s"AWS unknown error, service: $serviceName (check logs for stacktrace), $e"
         }
-        val friendlyMessage = serviceNameOpt.fold(s"Unknown error while making API calls to AWS. $e") { serviceName =>
+        val friendlyMessage = serviceNameOpt.fold(
+          s"Unknown error while making API calls to AWS. $e"
+        ) { serviceName =>
           s"Unknown error while making an API call to AWS' $serviceName service, $e"
         }
         Failure(details, friendlyMessage, AwsError, e).attempt
@@ -48,7 +92,10 @@ object AwsAsyncHandler {
     }
   }
 
-  class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T]) extends AsyncHandler[R, T] with LazyLogging {
+  class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](
+      promise: Promise[T]
+  ) extends AsyncHandler[R, T]
+      with LazyLogging {
     def onError(e: Exception): Unit = {
       logger.warn("Failed to execute AWS SDK operation", e)
       promise failure e

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -38,9 +38,7 @@ object EC2 {
       tagOrder.take(tagValues.length).map(makeFilter(_, allTags))
 
     val request = new DescribeInstancesRequest()
-      .withFilters(
-        filters: _*
-      )
+      .withFilters(filters*)
     handleAWSErrs(
       awsToScala(client.describeInstancesAsync)(request).map(extractInstances)
     )

--- a/src/main/scala/com/gu/ssm/aws/EC2.scala
+++ b/src/main/scala/com/gu/ssm/aws/EC2.scala
@@ -11,51 +11,77 @@ import com.gu.ssm.{Instance, InstanceId}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
-
 object EC2 {
-  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AmazonEC2Async = {
-    AmazonEC2AsyncClientBuilder.standard()
+  def client(
+      credentialsProvider: AWSCredentialsProvider,
+      region: Region
+  ): AmazonEC2Async = {
+    AmazonEC2AsyncClientBuilder
+      .standard()
       .withCredentials(credentialsProvider)
       .withRegion(region.getName)
       .build()
   }
 
-  def makeFilter(tagName: String, values: List[String]) = new Filter(s"tag:$tagName", values.asJava)
+  def makeFilter(tagName: String, values: List[String]) =
+    new Filter(s"tag:$tagName", values.asJava)
 
-  def resolveByTags(tagValues: List[String], client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
-    val allTags = tagValues ++ tagValues.map(_.toUpperCase) ++ tagValues.map(_.toLowerCase)
+  def resolveByTags(tagValues: List[String], client: AmazonEC2Async)(implicit
+      ec: ExecutionContext
+  ): Attempt[List[Instance]] = {
+    val allTags =
+      tagValues ++ tagValues.map(_.toUpperCase) ++ tagValues.map(_.toLowerCase)
 
     // if user has provided fewer than 3 tags then assume order app,stage,stack
     val tagOrder = List("App", "Stage", "Stack")
     val filters = new Filter("instance-state-name", List("running").asJava) ::
-        tagOrder.take(tagValues.length).map(makeFilter(_, allTags))
+      tagOrder.take(tagValues.length).map(makeFilter(_, allTags))
 
     val request = new DescribeInstancesRequest()
       .withFilters(
         filters: _*
       )
-    handleAWSErrs(awsToScala(client.describeInstancesAsync)(request).map(extractInstances))
+    handleAWSErrs(
+      awsToScala(client.describeInstancesAsync)(request).map(extractInstances)
+    )
   }
 
-  def resolveInstanceIds(ids: List[InstanceId], client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Instance]] = {
+  def resolveInstanceIds(ids: List[InstanceId], client: AmazonEC2Async)(implicit
+      ec: ExecutionContext
+  ): Attempt[List[Instance]] = {
     val request = new DescribeInstancesRequest()
       .withFilters(
         new Filter("instance-state-name", List("running").asJava),
         new Filter("instance-id", ids.map(i => i.id).asJava)
       )
-    handleAWSErrs(awsToScala(client.describeInstancesAsync)(request).map(extractInstances))
+    handleAWSErrs(
+      awsToScala(client.describeInstancesAsync)(request).map(extractInstances)
+    )
   }
 
-  private def extractInstances(describeInstancesResult: DescribeInstancesResult): List[Instance] = {
+  private def extractInstances(
+      describeInstancesResult: DescribeInstancesResult
+  ): List[Instance] = {
     (for {
       reservation <- describeInstancesResult.getReservations.asScala
       awsInstance <- reservation.getInstances.asScala
       instanceId = awsInstance.getInstanceId
       launchDateTime = awsInstance.getLaunchTime.toInstant
-    } yield Instance(InstanceId(instanceId), Option(awsInstance.getPublicDnsName), Option(awsInstance.getPublicIpAddress), awsInstance.getPrivateIpAddress, launchDateTime)).toList
+    } yield Instance(
+      InstanceId(instanceId),
+      Option(awsInstance.getPublicDnsName),
+      Option(awsInstance.getPublicIpAddress),
+      awsInstance.getPrivateIpAddress,
+      launchDateTime
+    )).toList
   }
 
-  def tagInstance(id: InstanceId, key: String, value: String, client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Unit] = {
+  def tagInstance(
+      id: InstanceId,
+      key: String,
+      value: String,
+      client: AmazonEC2Async
+  )(implicit ec: ExecutionContext): Attempt[Unit] = {
     val request = new CreateTagsRequest()
       .withTags(new Tag(key, value))
       .withResources(id.id)
@@ -63,5 +89,3 @@ object EC2 {
   }
 
 }
-
-

--- a/src/main/scala/com/gu/ssm/aws/SSM.scala
+++ b/src/main/scala/com/gu/ssm/aws/SSM.scala
@@ -3,7 +3,10 @@ package com.gu.ssm.aws
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.simplesystemsmanagement.model._
-import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagementAsync, AWSSimpleSystemsManagementAsyncClientBuilder}
+import com.amazonaws.services.simplesystemsmanagement.{
+  AWSSimpleSystemsManagementAsync,
+  AWSSimpleSystemsManagementAsyncClientBuilder
+}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import com.gu.ssm.utils.attempt.Attempt
 import com.gu.ssm.{CommandStatus, _}
@@ -12,58 +15,106 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-
 object SSM {
-  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AWSSimpleSystemsManagementAsync = {
-    AWSSimpleSystemsManagementAsyncClientBuilder.standard()
+  def client(
+      credentialsProvider: AWSCredentialsProvider,
+      region: Region
+  ): AWSSimpleSystemsManagementAsync = {
+    AWSSimpleSystemsManagementAsyncClientBuilder
+      .standard()
       .withCredentials(credentialsProvider)
       .withRegion(region.getName)
       .build()
   }
 
-  def sendCommand(instanceIds: List[InstanceId], cmd: String, username: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[String] = {
+  def sendCommand(
+      instanceIds: List[InstanceId],
+      cmd: String,
+      username: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit ec: ExecutionContext): Attempt[String] = {
     val parameters = Map("commands" -> List(cmd).asJava).asJava
     val sendCommandRequest = new SendCommandRequest()
       .withComment(s"Command submitted by $username")
       .withInstanceIds(instanceIds.map(_.id).asJava)
       .withDocumentName("AWS-RunShellScript")
       .withParameters(parameters)
-    handleAWSErrs(awsToScala(client.sendCommandAsync)(sendCommandRequest).map(extractCommandId))
+    handleAWSErrs(
+      awsToScala(client.sendCommandAsync)(sendCommandRequest)
+        .map(extractCommandId)
+    )
   }
 
   def extractCommandId(sendCommandResult: SendCommandResult): String = {
     sendCommandResult.getCommand.getCommandId
   }
 
-  def getCommandInvocation(instance: InstanceId, commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[Either[CommandStatus, CommandResult]] = {
+  def getCommandInvocation(
+      instance: InstanceId,
+      commandId: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit
+      ec: ExecutionContext
+  ): Attempt[Either[CommandStatus, CommandResult]] = {
     val request = new GetCommandInvocationRequest()
       .withCommandId(commandId)
       .withInstanceId(instance.id)
     handleAWSErrs(
       awsToScala(client.getCommandInvocationAsync)(request)
         .map(extractCommandResult)
-        .recover { case _:InvocationDoesNotExistException => Left(InvocationDoesNotExist) }
+        .recover { case _: InvocationDoesNotExistException =>
+          Left(InvocationDoesNotExist)
+        }
     )
   }
 
-  def extractCommandResult(getCommandInvocationResult: GetCommandInvocationResult): Either[CommandStatus, CommandResult] = {
+  def extractCommandResult(
+      getCommandInvocationResult: GetCommandInvocationResult
+  ): Either[CommandStatus, CommandResult] = {
     commandStatus(getCommandInvocationResult.getStatusDetails) match {
       case Success =>
-        Right(CommandResult(getCommandInvocationResult.getStandardOutputContent, getCommandInvocationResult.getStandardErrorContent, commandFailed = false))
+        Right(
+          CommandResult(
+            getCommandInvocationResult.getStandardOutputContent,
+            getCommandInvocationResult.getStandardErrorContent,
+            commandFailed = false
+          )
+        )
       case Failed =>
-        Right(CommandResult(getCommandInvocationResult.getStandardOutputContent, getCommandInvocationResult.getStandardErrorContent, commandFailed = true))
+        Right(
+          CommandResult(
+            getCommandInvocationResult.getStandardOutputContent,
+            getCommandInvocationResult.getStandardErrorContent,
+            commandFailed = true
+          )
+        )
       case status =>
         Left(status)
     }
   }
 
-  def getCmdOutput(instance: InstanceId, commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[(InstanceId, Either[CommandStatus, CommandResult])] = {
+  def getCmdOutput(
+      instance: InstanceId,
+      commandId: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit
+      ec: ExecutionContext
+  ): Attempt[(InstanceId, Either[CommandStatus, CommandResult])] = {
     for {
-      cmdResult <- Attempt.retryUntil(delayBetweenRetries = 500.millis, () => getCommandInvocation(instance, commandId, client))(_.isRight)
+      cmdResult <- Attempt.retryUntil(
+        delayBetweenRetries = 500.millis,
+        () => getCommandInvocation(instance, commandId, client)
+      )(_.isRight)
     } yield instance -> cmdResult
   }
 
-  def getCmdOutputs(instanceIds: List[InstanceId], commandId: String, client: AWSSimpleSystemsManagementAsync)(implicit ec: ExecutionContext): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
+  def getCmdOutputs(
+      instanceIds: List[InstanceId],
+      commandId: String,
+      client: AWSSimpleSystemsManagementAsync
+  )(implicit
+      ec: ExecutionContext
+  ): Attempt[List[(InstanceId, Either[CommandStatus, CommandResult])]] = {
     Attempt.traverse(instanceIds)(getCmdOutput(_, commandId, client))
   }
 

--- a/src/main/scala/com/gu/ssm/aws/STS.scala
+++ b/src/main/scala/com/gu/ssm/aws/STS.scala
@@ -3,30 +3,50 @@ package com.gu.ssm.aws
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Region
-import com.amazonaws.services.securitytoken.model.{GetCallerIdentityRequest, GetCallerIdentityResult}
-import com.amazonaws.services.securitytoken.{AWSSecurityTokenServiceAsync, AWSSecurityTokenServiceAsyncClientBuilder}
+import com.amazonaws.services.securitytoken.model.{
+  GetCallerIdentityRequest,
+  GetCallerIdentityResult
+}
+import com.amazonaws.services.securitytoken.{
+  AWSSecurityTokenServiceAsync,
+  AWSSecurityTokenServiceAsyncClientBuilder
+}
 import com.gu.ssm.aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import com.gu.ssm.utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
 
-
 object STS {
-  def client(credentialsProvider: AWSCredentialsProvider, region: Region): AWSSecurityTokenServiceAsync = {
-    AWSSecurityTokenServiceAsyncClientBuilder.standard()
+  def client(
+      credentialsProvider: AWSCredentialsProvider,
+      region: Region
+  ): AWSSecurityTokenServiceAsync = {
+    AWSSecurityTokenServiceAsyncClientBuilder
+      .standard()
       .withCredentials(credentialsProvider)
       // STS is a global service but you need to access the regional endpoint if using it through an endpoint in VPCs
       // that have no outbound internet access. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
-      .withEndpointConfiguration(new EndpointConfiguration(region.getServiceEndpoint("sts"), region.getName))
+      .withEndpointConfiguration(
+        new EndpointConfiguration(
+          region.getServiceEndpoint("sts"),
+          region.getName
+        )
+      )
       .build()
   }
 
-  def getCallerIdentity(client: AWSSecurityTokenServiceAsync)(implicit ec: ExecutionContext): Attempt[String] = {
+  def getCallerIdentity(
+      client: AWSSecurityTokenServiceAsync
+  )(implicit ec: ExecutionContext): Attempt[String] = {
     val request = new GetCallerIdentityRequest()
-    handleAWSErrs(awsToScala(client.getCallerIdentityAsync)(request).map(extractUserId))
+    handleAWSErrs(
+      awsToScala(client.getCallerIdentityAsync)(request).map(extractUserId)
+    )
   }
 
-  def extractUserId(getCallerIdentityResult: GetCallerIdentityResult): String = {
+  def extractUserId(
+      getCallerIdentityResult: GetCallerIdentityResult
+  ): String = {
     getCallerIdentityResult.getUserId
   }
 }

--- a/src/main/scala/com/gu/ssm/models.scala
+++ b/src/main/scala/com/gu/ssm/models.scala
@@ -8,43 +8,53 @@ import java.time.Instant
 import com.amazonaws.services.rds.AmazonRDSAsync
 
 case class InstanceId(id: String) extends AnyVal
-case class Instance(id: InstanceId, publicDomainNameOpt: Option[String], publicIpAddressOpt: Option[String], privateIpAddress: String, launchInstant: Instant)
+case class Instance(
+    id: InstanceId,
+    publicDomainNameOpt: Option[String],
+    publicIpAddressOpt: Option[String],
+    privateIpAddress: String,
+    launchInstant: Instant
+)
 case class AppStackStage(app: String, stack: String, stage: String)
-case class ExecutionTarget(instances: Option[List[InstanceId]] = None, tagValues: Option[List[String]] = None)
+case class ExecutionTarget(
+    instances: Option[List[InstanceId]] = None,
+    tagValues: Option[List[String]] = None
+)
 case class RDSInstanceId(id: String) extends AnyVal
 case class RDSInstance(id: RDSInstanceId, hostname: String, port: Int)
 
 case class Arguments(
-  verbose: Boolean,
-  executionTarget: Option[ExecutionTarget],
-  toExecute: Option[String],
-  profile: Option[String],
-  region: Region,
-  mode: Option[SsmMode],
-  targetInstanceUser: Option[String],
-  singleInstanceSelectionMode: SingleInstanceSelectionMode,
-  isSelectionModeNewest: Boolean,
-  isSelectionModeOldest: Boolean,
-  usePrivateIpAddress: Boolean,
-  rawOutput: Boolean,
-  bastionInstance: Option[ExecutionTarget],
-  bastionPortNumber: Option[Int],
-  bastionUser: Option[String],
-  targetInstancePortNumber: Option[Int],
-  useAgent: Option[Boolean],
-  hostKeyAlgPreference: List[String],
-  sourceFile: Option[String],
-  targetFile: Option[String],
-  tunnelThroughSystemsManager: Boolean,
-  useDefaultCredentialsProvider: Boolean,
-  tunnelTarget: Option[TunnelTargetWithHostName],
-  rdsTunnelTarget: Option[TunnelTargetWithRDSTags]
+    verbose: Boolean,
+    executionTarget: Option[ExecutionTarget],
+    toExecute: Option[String],
+    profile: Option[String],
+    region: Region,
+    mode: Option[SsmMode],
+    targetInstanceUser: Option[String],
+    singleInstanceSelectionMode: SingleInstanceSelectionMode,
+    isSelectionModeNewest: Boolean,
+    isSelectionModeOldest: Boolean,
+    usePrivateIpAddress: Boolean,
+    rawOutput: Boolean,
+    bastionInstance: Option[ExecutionTarget],
+    bastionPortNumber: Option[Int],
+    bastionUser: Option[String],
+    targetInstancePortNumber: Option[Int],
+    useAgent: Option[Boolean],
+    hostKeyAlgPreference: List[String],
+    sourceFile: Option[String],
+    targetFile: Option[String],
+    tunnelThroughSystemsManager: Boolean,
+    useDefaultCredentialsProvider: Boolean,
+    tunnelTarget: Option[TunnelTargetWithHostName],
+    rdsTunnelTarget: Option[TunnelTargetWithRDSTags]
 )
 
 object Arguments {
   val targetInstanceDefaultUser = "ubuntu"
   val bastionDefaultUser = "ubuntu"
-  val defaultHostKeyAlgPreference: List[String] = List("ecdsa-sha2-nistp256", "ssh-rsa")
+  val defaultHostKeyAlgPreference: List[String] =
+    List("ecdsa-sha2-nistp256", "ssh-rsa")
 
   def empty(): Arguments = Arguments(
     verbose = false,
@@ -94,21 +104,21 @@ case object SsmScp extends SsmMode
 
 case class CommandResult(stdOut: String, stdErr: String, commandFailed: Boolean)
 
-case class SSMConfig (
-  targets: List[Instance],
-  name: String
+case class SSMConfig(
+    targets: List[Instance],
+    name: String
 )
 
-case class AWSClients (
-  ssmClient: AWSSimpleSystemsManagementAsync,
-  stsClient: AWSSecurityTokenServiceAsync,
-  ec2Client: AmazonEC2Async,
-  rdsClient: AmazonRDSAsync
+case class AWSClients(
+    ssmClient: AWSSimpleSystemsManagementAsync,
+    stsClient: AWSSecurityTokenServiceAsync,
+    ec2Client: AmazonEC2Async,
+    rdsClient: AmazonRDSAsync
 )
 
 case class ResultsWithInstancesNotFound(
-  results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])],
-  instancesNotFound: List[InstanceId]
+    results: List[(InstanceId, scala.Either[CommandStatus, CommandResult])],
+    instancesNotFound: List[InstanceId]
 )
 
 sealed trait SingleInstanceSelectionMode
@@ -117,5 +127,11 @@ case object SismOldest extends SingleInstanceSelectionMode
 case object SismUnspecified extends SingleInstanceSelectionMode
 
 sealed trait TunnelTarget
-case class TunnelTargetWithRDSTags(localPort: Int, remoteTags: Seq[String]) extends TunnelTarget
-case class TunnelTargetWithHostName(localPort: Int, remoteHostName: String, remotePort: Int, remoteTags: Seq[String] = Seq.empty) extends TunnelTarget
+case class TunnelTargetWithRDSTags(localPort: Int, remoteTags: Seq[String])
+    extends TunnelTarget
+case class TunnelTargetWithHostName(
+    localPort: Int,
+    remoteHostName: String,
+    remotePort: Int,
+    remoteTags: Seq[String] = Seq.empty
+) extends TunnelTarget

--- a/src/main/scala/com/gu/ssm/utils/FilePermissions.scala
+++ b/src/main/scala/com/gu/ssm/utils/FilePermissions.scala
@@ -6,16 +6,16 @@ import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
 
 import scala.util.Try
 
-/**
-  * Setting the file permissions
+/** Setting the file permissions
   */
 object FilePermissions {
 
-  /**
-    * Using java 7 nio API to set the permissions.
+  /** Using java 7 nio API to set the permissions.
     *
-    * @param file to act on
-    * @param perms in octal format
+    * @param file
+    *   to act on
+    * @param perms
+    *   in octal format
     */
   def apply(file: File, perms: String): Unit = {
     val posix = PosixFilePermissions fromString convert(perms)
@@ -33,39 +33,46 @@ object FilePermissions {
     // propagate error
     if (result.isFailure) {
       val e = result.failed.get
-      sys.error("Error setting permissions " + perms + " on " + file.getAbsolutePath + ": " + e.getMessage)
+      sys.error(
+        "Error setting permissions " + perms + " on " + file.getAbsolutePath + ": " + e.getMessage
+      )
     }
   }
 
-  /**
-    * Converts a octal unix permission representation into
-    * a java `PosixFilePermissions` compatible string.
+  /** Converts a octal unix permission representation into a java
+    * `PosixFilePermissions` compatible string.
     */
-    def convert(perms: String): String = {
-      require(perms.length == 4 || perms.length == 3, s"Permissions must have 3 or 4 digits, got [$perms]")
-      // ignore setuid/setguid/sticky bit
-      val i = if (perms.length == 3) 0 else 1
-      val user = Character getNumericValue (perms charAt i)
-      val group = Character getNumericValue (perms charAt i + 1)
-      val other = Character getNumericValue (perms charAt i + 2)
+  def convert(perms: String): String = {
+    require(
+      perms.length == 4 || perms.length == 3,
+      s"Permissions must have 3 or 4 digits, got [$perms]"
+    )
+    // ignore setuid/setguid/sticky bit
+    val i = if (perms.length == 3) 0 else 1
+    val user = Character getNumericValue (perms charAt i)
+    val group = Character getNumericValue (perms charAt i + 1)
+    val other = Character getNumericValue (perms charAt i + 2)
 
-      permissionAsString(user) + permissionAsString(group) + permissionAsString(other)
-    }
+    permissionAsString(user) + permissionAsString(group) + permissionAsString(
+      other
+    )
+  }
 
-    def permissionAsString(perm: Int): String = perm match {
-      case 0 => "---"
-      case 1 => "--x"
-      case 2 => "-w-"
-      case 3 => "-wx"
-      case 4 => "r--"
-      case 5 => "r-x"
-      case 6 => "rw-"
-      case 7 => "rwx"
-    }
+  def permissionAsString(perm: Int): String = perm match {
+    case 0 => "---"
+    case 1 => "--x"
+    case 2 => "-w-"
+    case 3 => "-wx"
+    case 4 => "r--"
+    case 5 => "r-x"
+    case 6 => "rw-"
+    case 7 => "rwx"
+  }
 
-    /** Enriches string with `oct` interpolator, parsing string as base 8 integer. */
-    implicit class OctalString(val sc: StringContext) extends AnyVal {
-      def oct(args: Any*): Int = Integer.parseInt(sc.s(args: _*), 8)
-    }
+  /** Enriches string with `oct` interpolator, parsing string as base 8 integer.
+    */
+  implicit class OctalString(val sc: StringContext) extends AnyVal {
+    def oct(args: Any*): Int = Integer.parseInt(sc.s(args: _*), 8)
+  }
 
 }

--- a/src/main/scala/com/gu/ssm/utils/FilePermissions.scala
+++ b/src/main/scala/com/gu/ssm/utils/FilePermissions.scala
@@ -18,7 +18,7 @@ object FilePermissions {
     *   in octal format
     */
   def apply(file: File, perms: String): Unit = {
-    val posix = PosixFilePermissions fromString convert(perms)
+    val posix = PosixFilePermissions.fromString(convert(perms))
     val result = Try {
       Files.setPosixFilePermissions(file.toPath, posix)
     } recoverWith {
@@ -49,9 +49,9 @@ object FilePermissions {
     )
     // ignore setuid/setguid/sticky bit
     val i = if (perms.length == 3) 0 else 1
-    val user = Character getNumericValue (perms charAt i)
-    val group = Character getNumericValue (perms charAt i + 1)
-    val other = Character getNumericValue (perms charAt i + 2)
+    val user = Character.getNumericValue(perms.charAt(i))
+    val group = Character.getNumericValue(perms.charAt(i + 1))
+    val other = Character.getNumericValue(perms.charAt(i + 2))
 
     permissionAsString(user) + permissionAsString(group) + permissionAsString(
       other
@@ -72,7 +72,7 @@ object FilePermissions {
   /** Enriches string with `oct` interpolator, parsing string as base 8 integer.
     */
   implicit class OctalString(val sc: StringContext) extends AnyVal {
-    def oct(args: Any*): Int = Integer.parseInt(sc.s(args: _*), 8)
+    def oct(args: Any*): Int = Integer.parseInt(sc.s(args*), 8)
   }
 
 }

--- a/src/main/scala/com/gu/ssm/utils/KeyMaker.scala
+++ b/src/main/scala/com/gu/ssm/utils/KeyMaker.scala
@@ -14,7 +14,11 @@ import org.apache.commons.codec.binary.Base64
 
 object KeyMaker {
 
-  def makeKey (privateKeyFile: File, algorithm: String, provider: String): String = {
+  def makeKey(
+      privateKeyFile: File,
+      algorithm: String,
+      provider: String
+  ): String = {
     Security.addProvider(new BouncyCastleProvider)
     val keyPair = generateKeyPair(algorithm, provider)
     val priv = keyPair.getPrivate
@@ -33,26 +37,23 @@ object KeyMaker {
     val rsaPublicKey = key.asInstanceOf[BCRSAPublicKey]
     val byteOs: ByteArrayOutputStream = new ByteArrayOutputStream
     val dos = new DataOutputStream(byteOs)
-    dos.writeInt ("ssh-rsa".getBytes.length)
-    dos.write ("ssh-rsa".getBytes)
-    dos.writeInt (rsaPublicKey.getPublicExponent.toByteArray.length)
-    dos.write (rsaPublicKey.getPublicExponent.toByteArray)
-    dos.writeInt (rsaPublicKey.getModulus.toByteArray.length)
-    dos.write (rsaPublicKey.getModulus.toByteArray)
-    val publicKeyEncoded = new String (Base64.encodeBase64 (byteOs.toByteArray) )
+    dos.writeInt("ssh-rsa".getBytes.length)
+    dos.write("ssh-rsa".getBytes)
+    dos.writeInt(rsaPublicKey.getPublicExponent.toByteArray.length)
+    dos.write(rsaPublicKey.getPublicExponent.toByteArray)
+    dos.writeInt(rsaPublicKey.getModulus.toByteArray.length)
+    dos.write(rsaPublicKey.getModulus.toByteArray)
+    val publicKeyEncoded = new String(Base64.encodeBase64(byteOs.toByteArray))
     "ssh-rsa " + publicKeyEncoded + " " + description
   }
 
   private def writePemFile(key: Key, description: String, file: File): Unit = {
     val pemObject = new PemObject(description, key.getEncoded)
-    val pemWriter = new PemWriter(new OutputStreamWriter(new FileOutputStream(file)))
+    val pemWriter = new PemWriter(
+      new OutputStreamWriter(new FileOutputStream(file))
+    )
     pemWriter.writeObject(pemObject)
     pemWriter.close()
   }
 
 }
-
-
-
-
-

--- a/src/main/scala/com/gu/ssm/utils/attempt/Attempt.scala
+++ b/src/main/scala/com/gu/ssm/utils/attempt/Attempt.scala
@@ -6,69 +6,81 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 
-
-/**
-  * Represents a value that will need to be calculated using an asynchronous
+/** Represents a value that will need to be calculated using an asynchronous
   * computation that may fail.
   */
 case class Attempt[A] private (underlying: Future[Either[FailedAttempt, A]]) {
-  /**
-    * Change the value within an attempt
+
+  /** Change the value within an attempt
     */
   def map[B](f: A => B)(implicit ec: ExecutionContext): Attempt[B] =
     flatMap(a => Attempt.Right(f(a)))
 
-  /**
-    * Create an Attempt by combining this with the result of a dependant operation
-    * that returns a new Attempt.
+  /** Create an Attempt by combining this with the result of a dependant
+    * operation that returns a new Attempt.
     */
-  def flatMap[B](f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[B] = Attempt {
+  def flatMap[B](
+      f: A => Attempt[B]
+  )(implicit ec: ExecutionContext): Attempt[B] = Attempt {
     asFuture.flatMap {
       case Right(a) => f(a).asFuture
-      case Left(e) => Future.successful(Left(e))
+      case Left(e)  => Future.successful(Left(e))
     }
   }
 
-  /**
-    * Produce a value from an Attempt regardless of whether it failed or succeeded.
+  /** Produce a value from an Attempt regardless of whether it failed or
+    * succeeded.
     *
     * Note that Attempts are asynchronous so this must return a Future.
     */
-  def fold[B](failure: FailedAttempt => B, success: A => B)(implicit ec: ExecutionContext): Future[B] = {
+  def fold[B](failure: FailedAttempt => B, success: A => B)(implicit
+      ec: ExecutionContext
+  ): Future[B] = {
     asFuture.map(_.fold(failure, success))
   }
 
-  /**
-    * Combine this Attempt with another attempt without dependencies (in parallel).
+  /** Combine this Attempt with another attempt without dependencies (in
+    * parallel).
     */
-  def map2[B, C](bAttempt: Attempt[B])(f: (A, B) => C)(implicit ec: ExecutionContext): Attempt[C] = {
+  def map2[B, C](
+      bAttempt: Attempt[B]
+  )(f: (A, B) => C)(implicit ec: ExecutionContext): Attempt[C] = {
     Attempt.map2(this, bAttempt)(f)
   }
 
-  /**
-    * If there is an error in the Future itself (e.g. a timeout) we convert it to a
-    * Left so we have a consistent error representation. Unfortunately, this means
-    * the error isn't being handled properly so we're left with just the information
-    * provided by the exception.
+  /** If there is an error in the Future itself (e.g. a timeout) we convert it
+    * to a Left so we have a consistent error representation. Unfortunately,
+    * this means the error isn't being handled properly so we're left with just
+    * the information provided by the exception.
     *
-    * Try to avoid hitting this method's failure case by always handling Future errors
-    * and creating a suitable failure instance for the problem.
+    * Try to avoid hitting this method's failure case by always handling Future
+    * errors and creating a suitable failure instance for the problem.
     */
-  def asFuture(implicit ec: ExecutionContext): Future[Either[FailedAttempt, A]] = {
+  def asFuture(implicit
+      ec: ExecutionContext
+  ): Future[Either[FailedAttempt, A]] = {
     underlying recover { case err =>
-      val apiErrors = FailedAttempt(Failure(err.getMessage, "Unexpected error", UnhandledError, err))
+      val apiErrors = FailedAttempt(
+        Failure(err.getMessage, "Unexpected error", UnhandledError, err)
+      )
       scala.Left(apiErrors)
     }
   }
 
-  def delay(delay: FiniteDuration)(implicit ec: ExecutionContext): Attempt[A] = {
+  def delay(
+      delay: FiniteDuration
+  )(implicit ec: ExecutionContext): Attempt[A] = {
     Attempt.delay(delay).flatMap(_ => this)
   }
 
-  def onComplete[B](callback: Either[FailedAttempt, A] => B)(implicit ec: ExecutionContext): Unit = {
+  def onComplete[B](
+      callback: Either[FailedAttempt, A] => B
+  )(implicit ec: ExecutionContext): Unit = {
     this.asFuture.onComplete {
       case util.Failure(e) =>
-        throw new IllegalStateException("Unexpected error handling was bypassed")
+        throw new IllegalStateException(
+          "Unexpected error handling was bypassed"
+        )
       case util.Success(either) =>
         callback(either)
     }
@@ -76,49 +88,57 @@ case class Attempt[A] private (underlying: Future[Either[FailedAttempt, A]]) {
 }
 
 object Attempt {
-  def map2[A, B, C](aAttempt: Attempt[A], bAttempt: Attempt[B])(f: (A, B) => C)(implicit ec: ExecutionContext): Attempt[C] = {
+  def map2[A, B, C](aAttempt: Attempt[A], bAttempt: Attempt[B])(
+      f: (A, B) => C
+  )(implicit ec: ExecutionContext): Attempt[C] = {
     for {
       a <- aAttempt
       b <- bAttempt
     } yield f(a, b)
   }
 
-  /**
-    * Changes generated `List[Attempt[A]]` to `Attempt[List[A]]` via provided
+  /** Changes generated `List[Attempt[A]]` to `Attempt[List[A]]` via provided
     * traversal function (like `Future.traverse`).
     *
-    * This implementation returns the first failure in the resulting list,
-    * or the successful result.
+    * This implementation returns the first failure in the resulting list, or
+    * the successful result.
     */
-  def traverse[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[B]] = {
+  def traverse[A, B](
+      as: List[A]
+  )(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[B]] = {
     as.foldRight[Attempt[List[B]]](Right(Nil))(f(_).map2(_)(_ :: _))
   }
 
-  /**
-    * Using the provided traversal function, sequence the resulting attempts
+  /** Using the provided traversal function, sequence the resulting attempts
     * into a list that preserves failures.
     *
     * This is useful if failure is acceptable in part of the application.
     */
-  def traverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[Either[FailedAttempt, B]]] = {
+  def traverseWithFailures[A, B](as: List[A])(
+      f: A => Attempt[B]
+  )(implicit ec: ExecutionContext): Attempt[List[Either[FailedAttempt, B]]] = {
     sequenceWithFailures(as.map(f))
   }
 
-  /**
-    * As with `Future.sequence`, changes `List[Attempt[A]]` to `Attempt[List[A]]`.
+  /** As with `Future.sequence`, changes `List[Attempt[A]]` to
+    * `Attempt[List[A]]`.
     *
-    * This implementation returns the first failure in the list, or the successful result.
+    * This implementation returns the first failure in the list, or the
+    * successful result.
     */
-  def sequence[A](responses: List[Attempt[A]])(implicit ec: ExecutionContext): Attempt[List[A]] = {
+  def sequence[A](
+      responses: List[Attempt[A]]
+  )(implicit ec: ExecutionContext): Attempt[List[A]] = {
     traverse(responses)(identity)
   }
 
-  /**
-    * Sequence these attempts into a list that preserves failures.
+  /** Sequence these attempts into a list that preserves failures.
     *
     * This is useful if failure is acceptable in part of the application.
     */
-  def sequenceWithFailures[A](attempts: List[Attempt[A]])(implicit ec: ExecutionContext): Attempt[List[Either[FailedAttempt, A]]] = {
+  def sequenceWithFailures[A](
+      attempts: List[Attempt[A]]
+  )(implicit ec: ExecutionContext): Attempt[List[Either[FailedAttempt, A]]] = {
     Async.Right(Future.traverse(attempts)(_.asFuture))
   }
 
@@ -128,10 +148,12 @@ object Attempt {
   def fromOption[A](optA: Option[A], ifNone: FailedAttempt): Attempt[A] =
     fromEither(optA.toRight(ifNone))
 
-  /**
-    * Convert a plain `Future` value to an attempt by providing a recovery handler.
+  /** Convert a plain `Future` value to an attempt by providing a recovery
+    * handler.
     */
-  def fromFuture[A](future: Future[A])(recovery: PartialFunction[Throwable, FailedAttempt])(implicit ec: ExecutionContext): Attempt[A] = {
+  def fromFuture[A](future: Future[A])(
+      recovery: PartialFunction[Throwable, FailedAttempt]
+  )(implicit ec: ExecutionContext): Attempt[A] = {
     Attempt {
       future
         .map(scala.Right(_))
@@ -141,21 +163,26 @@ object Attempt {
     }
   }
 
-  /**
-    * Discard failures from a list of attempts.
+  /** Discard failures from a list of attempts.
     *
     * **Use with caution**.
     */
-  def successfulAttempts[A](attempts: List[Attempt[A]])(implicit ec: ExecutionContext): Attempt[List[A]] = {
+  def successfulAttempts[A](
+      attempts: List[Attempt[A]]
+  )(implicit ec: ExecutionContext): Attempt[List[A]] = {
     Attempt.Async.Right {
-      Future.traverse(attempts)(_.asFuture).map(_.collect { case Right(a) => a })
+      Future
+        .traverse(attempts)(_.asFuture)
+        .map(_.collect { case Right(a) => a })
     }
   }
 
-  /**
-    * Returns a successful attempt after a delay. Can be chained with other Attempts to delay those.
+  /** Returns a successful attempt after a delay. Can be chained with other
+    * Attempts to delay those.
     */
-  def delay(delay: FiniteDuration)(implicit ctx: ExecutionContext): Attempt[Unit] = {
+  def delay(
+      delay: FiniteDuration
+  )(implicit ctx: ExecutionContext): Attempt[Unit] = {
     val timer = new Timer()
     val prom = Promise[Unit]()
     val unitTask = new TimerTask {
@@ -164,19 +191,25 @@ object Attempt {
       }
     }
     timer.schedule(unitTask, delay.toMillis)
-    Attempt.fromFuture(prom.future) {
-      case NonFatal(e) => Failure("failed to run delay task", "Internal error while delaying operations", ErrorCode, e).attempt
+    Attempt.fromFuture(prom.future) { case NonFatal(e) =>
+      Failure(
+        "failed to run delay task",
+        "Internal error while delaying operations",
+        ErrorCode,
+        e
+      ).attempt
     }
   }
 
-  /**
-    * Retry an attempt until the condition is met.
+  /** Retry an attempt until the condition is met.
     *
-    * Note that this will fail immediately with the failure if a FailedAttempt is returned,
-    * this function is for testing the successful value.
+    * Note that this will fail immediately with the failure if a FailedAttempt
+    * is returned, this function is for testing the successful value.
     */
-  def retryUntil[A](delayBetweenRetries: FiniteDuration, attemptA: () => Attempt[A])(condition: A => Boolean)
-              (implicit ec: ExecutionContext): Attempt[A] = {
+  def retryUntil[A](
+      delayBetweenRetries: FiniteDuration,
+      attemptA: () => Attempt[A]
+  )(condition: A => Boolean)(implicit ec: ExecutionContext): Attempt[A] = {
     def loop(a: A, attemptCount: Int): Attempt[A] = {
       if (condition(a)) {
         Attempt.Right(a)
@@ -195,40 +228,39 @@ object Attempt {
     } yield result
   }
 
-  /**
-    * Create an Attempt instance from a "good" value.
+  /** Create an Attempt instance from a "good" value.
     */
   def Right[A](a: A): Attempt[A] =
     Attempt(Future.successful(scala.Right(a)))
 
-  /**
-    * Create an Attempt failure from an Failure instance, representing the possibility of multiple failures.
+  /** Create an Attempt failure from an Failure instance, representing the
+    * possibility of multiple failures.
     */
   def Left[A](errs: FailedAttempt): Attempt[A] =
     Attempt(Future.successful(scala.Left(errs)))
-  /**
-    * Syntax sugar to create an Attempt failure if there's only a single error.
+
+  /** Syntax sugar to create an Attempt failure if there's only a single error.
     */
   def Left[A](err: Failure): Attempt[A] =
     Attempt(Future.successful(scala.Left(FailedAttempt(err))))
 
-  /**
-    * Asyncronous versions of the Attempt Right/Left helpers for when you have
-    * a Future that returns a good/bad value directly.
+  /** Asyncronous versions of the Attempt Right/Left helpers for when you have a
+    * Future that returns a good/bad value directly.
     */
   object Async {
-    /**
-      * Create an Attempt from a Future of a good value.
+
+    /** Create an Attempt from a Future of a good value.
       */
     def Right[A](fa: Future[A])(implicit ec: ExecutionContext): Attempt[A] =
       Attempt(fa.map(scala.Right(_)))
 
-    /**
-      * Create an Attempt from a known failure in the future. For example,
-      * if a piece of logic fails but you need to make a Database/API call to
-      * get the failure information.
+    /** Create an Attempt from a known failure in the future. For example, if a
+      * piece of logic fails but you need to make a Database/API call to get the
+      * failure information.
       */
-    def Left[A](ferr: Future[FailedAttempt])(implicit ec: ExecutionContext): Attempt[A] =
+    def Left[A](ferr: Future[FailedAttempt])(implicit
+        ec: ExecutionContext
+    ): Attempt[A] =
       Attempt(ferr.map(scala.Left(_)))
   }
 }

--- a/src/main/scala/com/gu/ssm/utils/attempt/Failure.scala
+++ b/src/main/scala/com/gu/ssm/utils/attempt/Failure.scala
@@ -1,6 +1,5 @@
 package com.gu.ssm.utils.attempt
 
-
 case class FailedAttempt(failures: List[Failure]) {
   def exitCode: ExitCode = failures.map(_.exitCode).maxBy(_.code)
 }
@@ -15,31 +14,40 @@ object FailedAttempt {
 }
 
 case class Failure(
-  message: String,
-  friendlyMessage: String,
-  exitCode: ExitCode,
-  context: Option[String] = None,
-  throwable: Option[Throwable] = None
+    message: String,
+    friendlyMessage: String,
+    exitCode: ExitCode,
+    context: Option[String] = None,
+    throwable: Option[Throwable] = None
 ) {
   def attempt: FailedAttempt = FailedAttempt(this)
 }
 object Failure {
-  def apply(message: String,
-            friendlyMessage: String,
-            exitCode: ExitCode): Failure = apply(message, friendlyMessage, exitCode, None, None)
-  def apply(message: String,
-            friendlyMessage: String,
-            exitCode: ExitCode,
-            context: String): Failure = apply(message, friendlyMessage, exitCode, Some(context), None)
-  def apply(message: String,
-            friendlyMessage: String,
-            exitCode: ExitCode,
-            throwable: Throwable): Failure = apply(message, friendlyMessage, exitCode, None, Some(throwable))
-  def apply(message: String,
-            friendlyMessage: String,
-            exitCode: ExitCode,
-            context: String,
-            throwable: Throwable): Failure = apply(message, friendlyMessage, exitCode, Some(context), Some(throwable))
+  def apply(
+      message: String,
+      friendlyMessage: String,
+      exitCode: ExitCode
+  ): Failure = apply(message, friendlyMessage, exitCode, None, None)
+  def apply(
+      message: String,
+      friendlyMessage: String,
+      exitCode: ExitCode,
+      context: String
+  ): Failure = apply(message, friendlyMessage, exitCode, Some(context), None)
+  def apply(
+      message: String,
+      friendlyMessage: String,
+      exitCode: ExitCode,
+      throwable: Throwable
+  ): Failure = apply(message, friendlyMessage, exitCode, None, Some(throwable))
+  def apply(
+      message: String,
+      friendlyMessage: String,
+      exitCode: ExitCode,
+      context: String,
+      throwable: Throwable
+  ): Failure =
+    apply(message, friendlyMessage, exitCode, Some(context), Some(throwable))
 }
 
 sealed abstract class ExitCode(val code: Int)

--- a/src/test/scala/com/gu/ssm/MainTest.scala
+++ b/src/test/scala/com/gu/ssm/MainTest.scala
@@ -5,19 +5,23 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import com.gu.ssm.Logic.computeIncorrectInstances
 
-
 class MainTest extends AnyFreeSpec with Matchers with EitherValues {
 
   "computeIncorrectInstances" - {
     "should return empty list when matching list of Instance Ids" in {
-      val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"))))
+      val executionTarget =
+        ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"))))
       val instanceIds = List(InstanceId("i-096fdd62fd48b5b99"))
       computeIncorrectInstances(executionTarget, instanceIds) shouldEqual Nil
     }
     "should return incorrectly submitted Instance Id" in {
-      val executionTarget = ExecutionTarget(Some(List(InstanceId("i-096fdd62fd48b5b99"),InstanceId("i-12345"))))
+      val executionTarget = ExecutionTarget(
+        Some(List(InstanceId("i-096fdd62fd48b5b99"), InstanceId("i-12345")))
+      )
       val instanceIds = List(InstanceId("i-096fdd62fd48b5b99"))
-      computeIncorrectInstances(executionTarget, instanceIds) shouldEqual List(InstanceId("i-12345"))
+      computeIncorrectInstances(executionTarget, instanceIds) shouldEqual List(
+        InstanceId("i-12345")
+      )
     }
   }
 

--- a/src/test/scala/com/gu/ssm/SSHTest.scala
+++ b/src/test/scala/com/gu/ssm/SSHTest.scala
@@ -15,19 +15,27 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
     import SSH.addPublicKeyCommand
 
     "make ssh directory" in {
-      addPublicKeyCommand("user1", "XXX") should include ("/bin/mkdir -p /home/user1/.ssh;")
+      addPublicKeyCommand("user1", "XXX") should include(
+        "/bin/mkdir -p /home/user1/.ssh;"
+      )
     }
 
     "make authorised keys" in {
-      addPublicKeyCommand("user2", "XXX") should include ("/bin/echo 'XXX' >> /home/user2/.ssh/authorized_keys;")
+      addPublicKeyCommand("user2", "XXX") should include(
+        "/bin/echo 'XXX' >> /home/user2/.ssh/authorized_keys;"
+      )
     }
 
     "ensure authorised key file ownership is correct" in {
-      addPublicKeyCommand("user3", "XXX") should include ("/bin/chown user3 /home/user3/.ssh/authorized_keys;")
+      addPublicKeyCommand("user3", "XXX") should include(
+        "/bin/chown user3 /home/user3/.ssh/authorized_keys;"
+      )
     }
 
     "ensure authorised key file permissions are correct" in {
-      addPublicKeyCommand("user4", "XXX") should include ("/bin/chmod 0600 /home/user4/.ssh/authorized_keys;")
+      addPublicKeyCommand("user4", "XXX") should include(
+        "/bin/chmod 0600 /home/user4/.ssh/authorized_keys;"
+      )
     }
 
   }
@@ -36,23 +44,33 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
 
     "ensure motd command file is present" in {
       import SSH.addTaintedCommand
-      addTaintedCommand("XXX") should include ("test -f /etc/update-motd.d/99-tainted || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;")
+      addTaintedCommand("XXX") should include(
+        "test -f /etc/update-motd.d/99-tainted || /bin/echo -e '#!/bin/bash' | /usr/bin/sudo /usr/bin/tee -a /etc/update-motd.d/99-tainted >> /dev/null;"
+      )
     }
     "ensure motd command file contains tainted message" in {
       import SSH.addTaintedCommand
-      addTaintedCommand("XXX") should include ("This instance should be considered tainted.") // much text removed from this because of color codes
+      addTaintedCommand("XXX") should include(
+        "This instance should be considered tainted."
+      ) // much text removed from this because of color codes
     }
     "ensure motd command file contains accessed message" in {
       import SSH.addTaintedCommand
-      addTaintedCommand("XXX") should include ("It was accessed by XXX at") // much text removed from this because of color codes
+      addTaintedCommand("XXX") should include(
+        "It was accessed by XXX at"
+      ) // much text removed from this because of color codes
     }
     "ensure motd command file has correct permissions" in {
       import SSH.addTaintedCommand
-      addTaintedCommand("XXX") should include ("/bin/chmod 0755 /etc/update-motd.d/99-tainted;")
+      addTaintedCommand("XXX") should include(
+        "/bin/chmod 0755 /etc/update-motd.d/99-tainted;"
+      )
     }
     "ensure motd update is executed" in {
       import SSH.addTaintedCommand
-      addTaintedCommand("XXX") should include ("/usr/bin/sudo /bin/run-parts /etc/update-motd.d/ | /usr/bin/sudo /usr/bin/tee /run/motd.dynamic >> /dev/null;")
+      addTaintedCommand("XXX") should include(
+        "/usr/bin/sudo /bin/run-parts /etc/update-motd.d/ | /usr/bin/sudo /usr/bin/tee /run/motd.dynamic >> /dev/null;"
+      )
     }
   }
 
@@ -64,58 +82,197 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
     "create standard ssh command" - {
 
       val file = new File("/banana")
-      val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
+      val instance = Instance(
+        InstanceId("raspberry"),
+        None,
+        Some("34.1.1.10"),
+        "10.1.1.10",
+        Instant.now()
+      )
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
+        val (instanceId, _) = sshCmdStandard(false)(
+          file,
+          instance,
+          "user4",
+          "34.1.1.10",
+          None,
+          None,
+          Some(false),
+          None,
+          EU_WEST_1,
+          tunnelThroughSystemsManager = false,
+          tunnelTarget = None
+        )
         instanceId.id shouldEqual "raspberry"
       }
 
       "user command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
-          command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10;"""))
+          val (_, command) = sshCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            None,
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false,
+            tunnelTarget = None
+          )
+          command should contain(
+            Out(
+              """ssh -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10;"""
+            )
+          )
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
-          command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10;"""))
+          val (_, command) = sshCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            None,
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false,
+            tunnelTarget = None
+          )
+          command should contain(
+            Out(
+              """ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana user4@34.1.1.10;"""
+            )
+          )
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(new File("/tmp/hostsfile")), Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
-          command should contain (Out("""ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10;"""))
+          val (_, command) = sshCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            Some(new File("/tmp/hostsfile")),
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false,
+            tunnelTarget = None
+          )
+          command should contain(
+            Out(
+              """ssh -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana user4@34.1.1.10;"""
+            )
+          )
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = sshCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(true), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
-          command should contain (Out("""ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10;"""))
+          val (_, command) = sshCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            None,
+            Some(true),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false,
+            tunnelTarget = None
+          )
+          command should contain(
+            Out(
+              """ssh -o "IdentitiesOnly yes" -A -p 2345 -i /banana user4@34.1.1.10;"""
+            )
+          )
         }
       }
 
       "machine command" - {
         "is correctly formed without port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
-          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10""")
+          val (_, command) = sshCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            None,
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false,
+            tunnelTarget = None
+          )
+          command.head.text should equal(
+            """ssh -o "IdentitiesOnly yes" -a -i /banana -t -t user4@34.1.1.10"""
+          )
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = false, tunnelTarget = None)
-          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10""")
+          val (_, command) = sshCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            None,
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false,
+            tunnelTarget = None
+          )
+          command.head.text should equal(
+            """ssh -o "IdentitiesOnly yes" -a -p 2345 -i /banana -t -t user4@34.1.1.10"""
+          )
         }
       }
 
       "ssm tunnel" - {
         "is correctly formed" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = true, tunnelTarget = None)
-          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10""")
+          val (_, command) = sshCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            None,
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = true,
+            tunnelTarget = None
+          )
+          command.head.text should equal(
+            """ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10"""
+          )
         }
       }
 
       "ssh tunnel to remote host" - {
         "is correctly formed" in {
-          val (_, command) = sshCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, None, Some(false), None, EU_WEST_1, tunnelThroughSystemsManager = true, tunnelTarget = Some(TunnelTargetWithHostName(5000, "example-hostname.com", 5432)))
-          command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10 -L 5000:example-hostname.com:5432 -N -f""")
+          val (_, command) = sshCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            None,
+            Some(false),
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = true,
+            tunnelTarget =
+              Some(TunnelTargetWithHostName(5000, "example-hostname.com", 5432))
+          )
+          command.head.text should equal(
+            """ssh -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana -t -t user4@34.1.1.10 -L 5000:example-hostname.com:5432 -N -f"""
+          )
         }
       }
     }
@@ -123,96 +280,330 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
     "create bastion ssh command" - {
 
       val file = new File("/banana")
-      val bastionInstance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
-      val targetInstance = Instance(InstanceId("strawberry"), None, Some("34.1.1.11"), "10.1.1.11", Instant.now())
+      val bastionInstance = Instance(
+        InstanceId("raspberry"),
+        None,
+        Some("34.1.1.10"),
+        "10.1.1.10",
+        Instant.now()
+      )
+      val targetInstance = Instance(
+        InstanceId("strawberry"),
+        None,
+        Some("34.1.1.11"),
+        "10.1.1.11",
+        Instant.now()
+      )
 
       "instance id is correct" in {
-        val (instanceId, _) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
+        val (instanceId, _) = sshCmdBastion(false)(
+          file,
+          bastionInstance,
+          targetInstance,
+          "user5",
+          "34.1.1.10",
+          "10.1.1.11",
+          None,
+          "bastionuser",
+          None,
+          Some(false),
+          None
+        )
         instanceId.id shouldEqual "strawberry"
       }
 
       "user command" - {
         "contains the user instructions" in {
-          val (_, command) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
-          command should contain (Metadata(s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"))
+          val (_, command) = sshCmdBastion(false)(
+            file,
+            bastionInstance,
+            targetInstance,
+            "user5",
+            "34.1.1.10",
+            "10.1.1.11",
+            None,
+            "bastionuser",
+            None,
+            Some(false),
+            None
+          )
+          command should contain(
+            Metadata(
+              s"# Dryrun mode. The command below will remain valid for $sshCredentialsLifetimeSeconds seconds:"
+            )
+          )
         }
 
         "contains the ssh command" in {
-          val (_, command) = sshCmdBastion(false)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
-          command.find(_.isInstanceOf[Out]).head.text should include ("ssh")
+          val (_, command) = sshCmdBastion(false)(
+            file,
+            bastionInstance,
+            targetInstance,
+            "user5",
+            "34.1.1.10",
+            "10.1.1.11",
+            None,
+            "bastionuser",
+            None,
+            Some(false),
+            None
+          )
+          command.find(_.isInstanceOf[Out]).head.text should include("ssh")
         }
       }
 
       "machine command" - {
         "is well formed without any port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, None, None)
-            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              None,
+              "bastionuser",
+              None,
+              None,
+              None
+            )
+            command.head.text should equal(
+              """ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11"""
+            )
           }
 
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(false), None)
-            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              None,
+              "bastionuser",
+              None,
+              Some(false),
+              None
+            )
+            command.head.text should equal(
+              """ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11"""
+            )
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", None, Some(true), None)
-            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              None,
+              "bastionuser",
+              None,
+              Some(true),
+              None
+            )
+            command.head.text should equal(
+              """ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11"""
+            )
           }
         }
 
         "is well formed with target instance port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), None, None)
-            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              None,
+              "bastionuser",
+              Some(2345),
+              None,
+              None
+            )
+            command.head.text should equal(
+              """ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+            )
           }
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(false), None)
-            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              None,
+              "bastionuser",
+              Some(2345),
+              Some(false),
+              None
+            )
+            command.head.text should equal(
+              """ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+            )
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", None, "bastionuser", Some(2345), Some(true), None)
-            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              None,
+              "bastionuser",
+              Some(2345),
+              Some(true),
+              None
+            )
+            command.head.text should equal(
+              """ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 22 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+            )
           }
         }
 
         "is well formed with bastion port specification" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, None, None)
-            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              Some(1234),
+              "bastionuser",
+              None,
+              None,
+              None
+            )
+            command.head.text should equal(
+              """ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11"""
+            )
           }
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(false), None)
-            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              Some(1234),
+              "bastionuser",
+              None,
+              Some(false),
+              None
+            )
+            command.head.text should equal(
+              """ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11"""
+            )
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", None, Some(true), None)
-            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              Some(1234),
+              "bastionuser",
+              None,
+              Some(true),
+              None
+            )
+            command.head.text should equal(
+              """ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 22' -t -t user5@10.1.1.11"""
+            )
           }
         }
 
         "is well formed with both bastion port and target instance port specifications" - {
           "agent-agnostic" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), None, None)
-            command.head.text should equal ("""ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              Some(1234),
+              "bastionuser",
+              Some(2345),
+              None,
+              None
+            )
+            command.head.text should equal(
+              """ssh -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+            )
           }
 
           "no agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), None)
-            command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              Some(1234),
+              "bastionuser",
+              Some(2345),
+              Some(false),
+              None
+            )
+            command.head.text should equal(
+              """ssh -a -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+            )
           }
 
           "with agent" in {
-            val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(true), None)
-            command.head.text should equal ("""ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+            val (_, command) = sshCmdBastion(true)(
+              file,
+              bastionInstance,
+              targetInstance,
+              "user5",
+              "34.1.1.10",
+              "10.1.1.11",
+              Some(1234),
+              "bastionuser",
+              Some(2345),
+              Some(true),
+              None
+            )
+            command.head.text should equal(
+              """ssh -A -o "IdentitiesOnly yes" -i /banana -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+            )
           }
         }
 
         "is well formed with a host key file" in {
-          val (_, command) = sshCmdBastion(true)(file, bastionInstance, targetInstance, "user5", "34.1.1.10", "10.1.1.11", Some(1234), "bastionuser", Some(2345), Some(false), Some(new File("/tmp/hostfile")))
-          command.head.text should equal ("""ssh -a -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11""")
+          val (_, command) = sshCmdBastion(true)(
+            file,
+            bastionInstance,
+            targetInstance,
+            "user5",
+            "34.1.1.10",
+            "10.1.1.11",
+            Some(1234),
+            "bastionuser",
+            Some(2345),
+            Some(false),
+            Some(new File("/tmp/hostfile"))
+          )
+          command.head.text should equal(
+            """ssh -a -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -o 'ProxyCommand ssh -o "IdentitiesOnly yes" -i /banana -o "UserKnownHostsFile /tmp/hostfile" -o "StrictHostKeyChecking yes" -p 1234 bastionuser@34.1.1.10 nc 10.1.1.11 2345' -t -t user5@10.1.1.11"""
+          )
         }
       }
     }
@@ -224,10 +615,29 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
     "create standard scp command" - {
 
       val file = new File("/banana")
-      val instance = Instance(InstanceId("raspberry"), None, Some("34.1.1.10"), "10.1.1.10", Instant.now())
+      val instance = Instance(
+        InstanceId("raspberry"),
+        None,
+        Some("34.1.1.10"),
+        "10.1.1.10",
+        Instant.now()
+      )
 
       "instance id is correct" in {
-        val (instanceId, _) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
+        val (instanceId, _) = scpCmdStandard(false)(
+          file,
+          instance,
+          "user4",
+          "34.1.1.10",
+          None,
+          Some(false),
+          None,
+          "/path/to/sourceFile",
+          ":/path/to/targetFile",
+          None,
+          EU_WEST_1,
+          tunnelThroughSystemsManager = false
+        )
         instanceId.id shouldEqual "raspberry"
       }
 
@@ -236,37 +646,154 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
         "process correctly remote server specifications" - {
 
           "target file is remote" in {
-            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-            command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
+            val (_, command) = scpCmdStandard(false)(
+              file,
+              instance,
+              "user4",
+              "34.1.1.10",
+              None,
+              Some(false),
+              None,
+              "/path/to/sourceFile",
+              ":/path/to/targetFile",
+              None,
+              EU_WEST_1,
+              tunnelThroughSystemsManager = false
+            )
+            command should contain(
+              Out(
+                """scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""
+              )
+            )
           }
           "source file is remote" in {
-            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-            command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile;"""))
+            val (_, command) = scpCmdStandard(false)(
+              file,
+              instance,
+              "user4",
+              "34.1.1.10",
+              None,
+              Some(false),
+              None,
+              ":/path/to/sourceFile",
+              "/path/to/targetFile",
+              None,
+              EU_WEST_1,
+              tunnelThroughSystemsManager = false
+            )
+            command should contain(
+              Out(
+                """scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile;"""
+              )
+            )
           }
           "incorrect specifications in" in {
-            val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-            command.head.text should include ("Incorrect remote server specifications")
+            val (_, command) = scpCmdStandard(false)(
+              file,
+              instance,
+              "user4",
+              "34.1.1.10",
+              None,
+              Some(false),
+              None,
+              ":/path/to/sourceFile",
+              ":/path/to/targetFile",
+              None,
+              EU_WEST_1,
+              tunnelThroughSystemsManager = false
+            )
+            command.head.text should include(
+              "Incorrect remote server specifications"
+            )
           }
         }
 
         "is correctly formed without port specification" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-          command should contain (Out("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
+          val (_, command) = scpCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            Some(false),
+            None,
+            "/path/to/sourceFile",
+            ":/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false
+          )
+          command should contain(
+            Out(
+              """scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""
+            )
+          )
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-          command should contain (Out("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
+          val (_, command) = scpCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            Some(false),
+            None,
+            "/path/to/sourceFile",
+            ":/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false
+          )
+          command should contain(
+            Out(
+              """scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""
+            )
+          )
         }
 
         "is correctly formed with a hosts file" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), Some(new File("/tmp/hostsfile")), "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-          command should contain (Out("""scp -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
+          val (_, command) = scpCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            Some(false),
+            Some(new File("/tmp/hostsfile")),
+            "/path/to/sourceFile",
+            ":/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false
+          )
+          command should contain(
+            Out(
+              """scp -o "IdentitiesOnly yes" -a -o "UserKnownHostsFile /tmp/hostsfile" -o "StrictHostKeyChecking yes" -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""
+            )
+          )
         }
 
         "is correctly formed with agent forwarding file" in {
-          val (_, command) = scpCmdStandard(false)(file, instance, "user4", "34.1.1.10", Some(2345), Some(true), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-          command should contain (Out("""scp -o "IdentitiesOnly yes" -A -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""))
+          val (_, command) = scpCmdStandard(false)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            Some(true),
+            None,
+            "/path/to/sourceFile",
+            ":/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false
+          )
+          command should contain(
+            Out(
+              """scp -o "IdentitiesOnly yes" -A -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile;"""
+            )
+          )
         }
       }
 
@@ -274,34 +801,124 @@ class SSHTest extends AnyFreeSpec with Matchers with EitherValues {
         "process correctly remote server specifications" - {
 
           "target file is remote" in {
-            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+            val (_, command) = scpCmdStandard(true)(
+              file,
+              instance,
+              "user4",
+              "34.1.1.10",
+              None,
+              Some(false),
+              None,
+              "/path/to/sourceFile",
+              ":/path/to/targetFile",
+              None,
+              EU_WEST_1,
+              tunnelThroughSystemsManager = false
+            )
+            command.head.text should equal(
+              """scp -o "IdentitiesOnly yes" -a -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile"""
+            )
           }
           "source file is remote" in {
-            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-            command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+            val (_, command) = scpCmdStandard(true)(
+              file,
+              instance,
+              "user4",
+              "34.1.1.10",
+              None,
+              Some(false),
+              None,
+              ":/path/to/sourceFile",
+              "/path/to/targetFile",
+              None,
+              EU_WEST_1,
+              tunnelThroughSystemsManager = false
+            )
+            command.head.text should equal(
+              """scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile"""
+            )
           }
           "incorrect specifications in" in {
-            val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-            command.head.text should include ("Incorrect remote server specifications")
+            val (_, command) = scpCmdStandard(true)(
+              file,
+              instance,
+              "user4",
+              "34.1.1.10",
+              None,
+              Some(false),
+              None,
+              ":/path/to/sourceFile",
+              ":/path/to/targetFile",
+              None,
+              EU_WEST_1,
+              tunnelThroughSystemsManager = false
+            )
+            command.head.text should include(
+              "Incorrect remote server specifications"
+            )
           }
         }
 
         "is correctly formed without port specification" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, ":/path/to/sourceFile", "/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile""")
+          val (_, command) = scpCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            Some(false),
+            None,
+            ":/path/to/sourceFile",
+            "/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false
+          )
+          command.head.text should equal(
+            """scp -o "IdentitiesOnly yes" -a -i /banana user4@34.1.1.10:/path/to/sourceFile /path/to/targetFile"""
+          )
         }
 
         "is correctly formed with port specification" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", Some(2345), Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = false)
-          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          val (_, command) = scpCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            Some(2345),
+            Some(false),
+            None,
+            "/path/to/sourceFile",
+            ":/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = false
+          )
+          command.head.text should equal(
+            """scp -o "IdentitiesOnly yes" -a -p 2345 -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile"""
+          )
         }
       }
 
       "ssm tunnel" - {
         "is correctly formed" in {
-          val (_, command) = scpCmdStandard(true)(file, instance, "user4", "34.1.1.10", None, Some(false), None, "/path/to/sourceFile", ":/path/to/targetFile", None, EU_WEST_1, tunnelThroughSystemsManager = true)
-          command.head.text should equal ("""scp -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile""")
+          val (_, command) = scpCmdStandard(true)(
+            file,
+            instance,
+            "user4",
+            "34.1.1.10",
+            None,
+            Some(false),
+            None,
+            "/path/to/sourceFile",
+            ":/path/to/targetFile",
+            None,
+            EU_WEST_1,
+            tunnelThroughSystemsManager = true
+          )
+          command.head.text should equal(
+            """scp -o "IdentitiesOnly yes" -a -o "ProxyCommand sh -c \"aws ssm start-session --target raspberry --document-name AWS-StartSSHSession --parameters 'portNumber=22' --region eu-west-1 \"" -i /banana /path/to/sourceFile user4@34.1.1.10:/path/to/targetFile"""
+          )
         }
       }
     }

--- a/src/test/scala/com/gu/ssm/UITest.scala
+++ b/src/test/scala/com/gu/ssm/UITest.scala
@@ -7,18 +7,26 @@ class UITest extends AnyFreeSpec with Matchers {
   "hasAnyCommandFailed" - {
     "returns false if no commands failed" in {
       val command = CommandResult("", "", commandFailed = false)
-      UI.hasAnyCommandFailed(List(InstanceId("test") -> Right(command))) shouldBe false
+      UI.hasAnyCommandFailed(
+        List(InstanceId("test") -> Right(command))
+      ) shouldBe false
     }
 
     "returns true if a single command failed" in {
       val command = CommandResult("", "", commandFailed = true)
-      UI.hasAnyCommandFailed(List(InstanceId("test") -> Right(command))) shouldBe true
+      UI.hasAnyCommandFailed(
+        List(InstanceId("test") -> Right(command))
+      ) shouldBe true
     }
 
     "returns true if at least one command failed" in {
       val commands = List(
-        InstanceId("test1") -> Right(CommandResult("", "", commandFailed = true)),
-        InstanceId("test2") -> Right(CommandResult("", "", commandFailed = false))
+        InstanceId("test1") -> Right(
+          CommandResult("", "", commandFailed = true)
+        ),
+        InstanceId("test2") -> Right(
+          CommandResult("", "", commandFailed = false)
+        )
       )
 
       UI.hasAnyCommandFailed(commands) shouldBe true

--- a/src/test/scala/com/gu/ssm/utils/attempt/AttemptTest.scala
+++ b/src/test/scala/com/gu/ssm/utils/attempt/AttemptTest.scala
@@ -10,8 +10,11 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-
-class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with AttemptValues {
+class AttemptTest
+    extends AnyFreeSpec
+    with Matchers
+    with EitherValues
+    with AttemptValues {
   "traverse" - {
     "returns the first failure" in {
       def failOnFourAndSix(i: Int): Attempt[Int] = {
@@ -21,12 +24,18 @@ class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with Attem
           case n => Right(n)
         }
       }
-      val errors = Attempt.traverse(List(1, 2, 3, 4, 5, 6))(failOnFourAndSix).leftValue()
+      val errors =
+        Attempt.traverse(List(1, 2, 3, 4, 5, 6))(failOnFourAndSix).leftValue()
       checkError(errors, "fails on four")
     }
 
     "returns the successful result if there were no failures" in {
-      Attempt.traverse(List(1, 2, 3, 4))(Right).value() shouldEqual List(1, 2, 3, 4)
+      Attempt.traverse(List(1, 2, 3, 4))(Right).value() shouldEqual List(
+        1,
+        2,
+        3,
+        4
+      )
     }
   }
 
@@ -38,7 +47,8 @@ class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with Attem
     }
 
     "returns only the successful attempts if there were failures" in {
-      val attempts: List[Attempt[Int]] = List(Right(1), Right(2), expectedFailure("failed"), Right(4))
+      val attempts: List[Attempt[Int]] =
+        List(Right(1), Right(2), expectedFailure("failed"), Right(4))
 
       Attempt.successfulAttempts(attempts).value() shouldEqual List(1, 2, 4)
     }
@@ -60,7 +70,9 @@ class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with Attem
 
   "retry" - {
     "returns success if the attempt returns successfully" in {
-      Attempt.retryUntil(Duration.Zero, () => Attempt.Right(true))(_ == true).isSuccessfulAttempt() shouldEqual true
+      Attempt
+        .retryUntil(Duration.Zero, () => Attempt.Right(true))(_ == true)
+        .isSuccessfulAttempt() shouldEqual true
     }
 
     "returns true if the attempt returns after retrying" in {
@@ -70,17 +82,25 @@ class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with Attem
         Attempt.Right(counter)
       }
 
-      Attempt.retryUntil(Duration.Zero, () => incr())(_ > 3).value() shouldEqual 4
+      Attempt
+        .retryUntil(Duration.Zero, () => incr())(_ > 3)
+        .value() shouldEqual 4
     }
 
     "returns failure if the attempt fails" in {
       val failure = Failure("test failure", "Test failure", ErrorCode).attempt
-      Attempt.retryUntil(Duration.Zero, () => Attempt.Left[Boolean](failure))(_ => true).leftValue() shouldEqual failure
+      Attempt
+        .retryUntil(Duration.Zero, () => Attempt.Left[Boolean](failure))(_ =>
+          true
+        )
+        .leftValue() shouldEqual failure
     }
 
     "delays between retrying" - {
       "and thus will time out in this test" in {
-        val future = Attempt.retryUntil(10.millis, () => Attempt.Right(false))(_ == true).asFuture
+        val future = Attempt
+          .retryUntil(10.millis, () => Attempt.Right(false))(_ == true)
+          .asFuture
         intercept[TimeoutException] {
           Await.result(future, 25.millis)
         }
@@ -88,11 +108,11 @@ class AttemptTest extends AnyFreeSpec with Matchers with EitherValues with Attem
     }
   }
 
-  /**
-    * Utilities for checking the failure state of attempts
+  /** Utilities for checking the failure state of attempts
     */
   def checkError(errors: FailedAttempt, expected: String): Unit = {
     errors.failures.head.message shouldEqual expected
   }
-  def expectedFailure[A](message: String): Attempt[A] = Left[A](Failure(message, "this will fail", ErrorCode))
+  def expectedFailure[A](message: String): Attempt[A] =
+    Left[A](Failure(message, "this will fail", ErrorCode))
 }


### PR DESCRIPTION
**NOTE:** this PR is currently based on [the remove-repl-mode PR](https://github.com/guardian/ssm-scala/pull/462), since there's no need to fix issues with code that is being removed.

## What does this change?

This is just about tidying things up ahead of future changes.

Introduces scalafmt into the codebase, to stop us having to think about how things are formatted. We also address the compiler warnings in the project.

## What is the value of this?

Tidies things up ahead of updating the AWS Java SDK to v2.

## Any additional notes?

The PR simplifies the implementation of the instance resolution logic, to address an incomplete match warning. Other compiler warnings are mostly about Scala 2.x -> 3.x changes, and have been fixed.

A few deprecation warnings remain relating to the AWS v1 SDK (specifically, the use of `Regions`). The v1 SDK will shortly be replaced with the supported v2 Java SDK, so we can leave these for now.