### PR TITLE
Chore: Prepare for release of v3.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "ssm-scala"
 organization := "com.gu"
-version := "3.7.1"
+version := "3.8.1"
 
 // be sure to also update this in the `generate-executable.sh` script
 scalaVersion := "3.7.2"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "ssm-scala"
 organization := "com.gu"
-version := "3.8.1"
+version := "3.8.0"
 
 // be sure to also update this in the `generate-executable.sh` script
 scalaVersion := "3.7.2"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "3.8.0"
 // be sure to also update this in the `generate-executable.sh` script
 scalaVersion := "3.7.2"
 
-val awsSdkVersion = "2.31.78"
+val awsSdkVersion = "2.32.26"
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "ssm" % awsSdkVersion,

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SCALA_FOLDER="scala-3.7.1"
+SCALA_FOLDER="scala-3.7.2"
 cd $DIR
 sbt assembly
 cat "$DIR/generate-executable-prefix" "$DIR/target/$SCALA_FOLDER/ssm.jar" > "$DIR/target/$SCALA_FOLDER/ssm"


### PR DESCRIPTION
For future viewers, this is following the [instructions in Readme](https://github.com/guardian/ssm-scala?tab=readme-ov-file#release-a-new-version).
