### PR TITLE
retain the services directory when assembling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,14 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
 
-// Required as jackson causes a merge issue with sbt-assembly
-// See: https://github.com/sbt/sbt-assembly/issues/391
+// Discard required as jackson causes a merge issue with sbt-assembly,
+// while we need to keep services for AWS SDK.
+// See: https://github.com/sbt/sbt-assembly/issues/391,
+// https://github.com/aws/aws-sdk-java-v2/issues/446
 assemblyMergeStrategy := {
-  case PathList("META-INF", _*) => MergeStrategy.discard
-  case _                        => MergeStrategy.first
+  case PathList("META-INF", "services", _*) => MergeStrategy.deduplicate
+  case PathList("META-INF", _*)             => MergeStrategy.discard
+  case _                                    => MergeStrategy.first
 }
 assemblyJarName := "ssm.jar"
 


### PR DESCRIPTION
## What does this change?

<!-- Screenshots may be helpful to demonstrate -->

Followup to #483 to adjust the assembly merge strategy to handle the AWS SDK v2, which requires us to retain some files in META-INF/services to enable the HTTP clients. As a side bonus, doing so also resolves the SLF4J warnings that "No SLF4J providers were found."


## What is the value of this?

The executable can now run without a stack trace complaining about missing SDK.


## Any additional notes?

We could use MergeStrategy.first instead, like the final fallback case, but deduplicate makes more sense to me, since if the overlapping files aren't identical then we should probably do some investigation to check which one should be kept, rather than assuming the first will be fine. See https://github.com/sbt/sbt-assembly?tab=readme-ov-file#merge-strategy for other options