### PR TITLE
feat: Add version argument option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,11 @@ version := "3.8.1"
 // be sure to also update this in the `generate-executable.sh` script
 scalaVersion := "3.7.2"
 
+// Enable BuildInfo plugin to generate version information
+enablePlugins(BuildInfoPlugin)
+buildInfoKeys := Seq[BuildInfoKey](name, version)
+buildInfoPackage := "com.gu.ssm"
+
 val awsSdkVersion = "2.32.26"
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/src/main/scala/com/gu/ssm/ArgumentParser.scala
+++ b/src/main/scala/com/gu/ssm/ArgumentParser.scala
@@ -13,6 +13,11 @@ object ArgumentParser {
 
     help("help").text("prints this usage text")
 
+    opt[Unit]('v', "version").action((_, _) => {
+      println(s"${BuildInfo.name} ${BuildInfo.version}")
+      sys.exit(0)
+    }).text("Show version information")
+
     opt[String]('p', "profile").optional()
       .action { (profile, args) =>
         args.copy(profile = Some(profile))


### PR DESCRIPTION
## What does this change?
Adds a `-v` option to show which version of ssm is in use.
eg. `ssm -v` or `ssm --version`
would give `ssm-scala 3.8.1` at the moment.

## What is the value of this?
If you make a fix and it doesn't work, the first thing that would be handy is to check that you're using the version you think you are.
