### PR TITLE
Update docs: Use current `brew` install syntax for `cask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Upgrade your local version of ssm and awscli:
 You'll also need to install the systems manager plugin on your machine:
 
 ```
-  brew cask install session-manager-plugin
+  brew install --cask session-manager-plugin
 ```
 
 You can then SSH using SSM with the default arguments:


### PR DESCRIPTION
The readme advises this outdated syntax:

```
brew cask install session-manager-plugin
```

...which fails in current `brew` with:

```
Error: Invalid usage: Unknown command: brew cask
```

Looking at the docs for this package:

https://formulae.brew.sh/cask/session-manager-plugin

...we can see that `brew` now advise:

```
brew install --cask session-manager-plugin
```

Note also that this cask is deprecated and has a 'disable date' of  2026-09-01 - but that is Another Problem: 

> Warning: session-manager-plugin has been deprecated because it does not pass the macOS Gatekeeper check! It will be disabled on 2026-09-01.
