### PR TITLE
Fix: propagate non-zero exit codes through shell wrapper pipeline

### DIFF
--- a/generate-executable-prefix
+++ b/generate-executable-prefix
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -o pipefail
 MYSELF=`which "$0" 2>/dev/null`
 [ $? -gt 0 -a -f "$0" ] && MYSELF="./$0"
 java=java


### PR DESCRIPTION
## What does this change?

I've become of aware of a subtle issue when scripting around `ssm` and trying to do custom error handling. When a command leads to an error condition, the exit code is always 0 (i.e. reported successful)

```bash
$ ~ % ssm ssh -p "typo" -x -t "typo","PROD"
Unknown error while making API calls to AWS. software.amazon.awssdk.core.exception.SdkClientException: Profile file contained no credentials for profile 'typo':[...])
$ ~ % echo $?
0
$ ~ % ssm ssh -p "expired" -x -t "typo","PROD"
Failed to request data from AWS, the temporary credentials have expired
$ ~ % echo $?                                          
0
$ ~ % ssm ssh -p "deployTools" -x -t "typo","PROD"
Could not find any instance
$ ~ % echo $?
0
```

Oddly, in `--dryrun` mode the correct behaviour is observed
```bash 
Unknown error while making API calls to AWS. software.amazon.awssdk.core.exception.SdkClientException: Profile file contained no credentials for profile 'typo':[...])
$ ~ % echo $?
4
$ ~ % ssm ssh -p "expired" -x -t "typo","PROD" --dryrun
Failed to request data from AWS, the temporary credentials have expired
$ ~ % echo $?                                          
3
$ ~ % ssm ssh -p "deployTools" -x -t "typo","PROD" --dryrun
Could not find any instance
$ ~ % echo $?
255
```

Turns out that this is due to the fact that we're using `bin/sh`, which does not propagate error codes in "pipeline" commands based on `|`. Knowing this, the reason for the difference in behaviour becomes clear in the following snippet
https://github.com/guardian/ssm-scala/blob/a0e770802c2f637cf2121e819d64ae8b7a0b0257/generate-executable-prefix#L18-L22

`--dryrun` does not use pipes, so the client gets the error code. When not in dry run, the java process fails, but xargs presumably does not, and so we get its success code instead.

This patch switches the script to `/bin/bash` and enables `set -o pipefail` so that error codes are propagated properly in the `| xargs` pipeline.

## How has this change been tested?

Compiled locally and ran the same commands. Dry run behaviour is preserved, and correct behaviour is now observed in regular mode.

```bash
$ ssm-scala % ./target/scala-3.3.7/ssm ssh -p "typo" -x -t "typo","PROD"
Unknown error while making API calls to AWS. software.amazon.awssdk.core.exception.SdkClientException: Profile file contained no credentials for profile 'typo': [...]
$ % echo $?
4
$ ssm-scala % ./target/scala-3.3.7/ssm ssh -p "expired" -x -t "typo","PROD"
Failed to request data from AWS, the temporary credentials have expired
$ ssm-scala % echo $?
3
$ ssm-scala % ./target/scala-3.3.7/ssm ssh -p "deployTools" -x -t "typo","PROD"
Could not find any instance
$ ssm-scala % echo $?
255
```

Also tested the actual successful scenario of sshing to a box and logging out, which returns 0 as expected.

```bash
$ ssm-scala % ./target/scala-3.3.7/ssm ssh -p "deployTools" -x -t "amigo","CODE" --newest                               
Welcome to Ubuntu 22.04.5 LTS (GNU/Linux 6.8.0-1052-aws aarch64)

[...]
ubuntu@ip-10-248-49-31:~$ 
logout
Connection to 10.248.49.31 closed.
$ ssm-scala % echo $?
0
```


## Have we considered potential risks?

The main risk is that this breaks ssh access for developers. I think the users should be able to report the issue and downgrade to the last working version, so I don't think it wouldn't be massively disruptive.
